### PR TITLE
Add paragraph about local simulation and move other paragraphs to a new sub-section

### DIFF
--- a/src/content/hardhat3-alpha/index.md
+++ b/src/content/hardhat3-alpha/index.md
@@ -165,11 +165,7 @@ You can learn more about how to customize your Solidity version and settings in 
 
 Tests are a critical part of any Ethereum project. Hardhat lets you write tests in both **Solidity** and **TypeScript**, giving you flexibility to choose the right tool for each situation.
 
-Solidity tests run directly on the EVM and are great for unit tests. They execute in a controlled environment, making them fast and deterministic. They also have access to test-related EVM extensions, normally called cheatcodes, which allow you to build complex tests in Solidity.
-
-TypeScript tests, on the other hand, use a fully-simulated local blockchain and interact with it through JSON-RPC. This allows you to write more complex or end-to-end tests using the full power of a general-purpose programming language and a realistic blockchain simulation. You can use any Ethereum TypeScript library, like [viem](https://viem.sh/) or [ethers.js](https://docs.ethers.org/v5/) to write your tests.
-
-Use Solidity when you want low-level, efficient, EVM-native tests. Use TypeScript when you want richer tooling, more flexible assertions, or to test blockchain-level interactions, like workflows involving multiple transactions.
+Hardhat tests run against a local in-memory blockchain, which is much faster than using a real network and doesn't require you to spend ETH or obtain testnet tokens.
 
 ### Solidity tests
 
@@ -353,6 +349,14 @@ This test deploys the `Counter` contract, calls `incBy` multiple times (each in 
 Writing this same test in Solidity is possible, but less convenient, and the test would be executed in a different context — closer to a single transaction calling the contract multiple times, than different users interacting with it over time. This makes TypeScript a better fit for scenarios that depend on realistic transaction flows or blockchain behavior.
 
 You can write any TypeScript code you want in your tests, as they are normal TypeScript files with access to Hardhat. In this example, we use `viem` to interact with the contracts and test the expected behavior. To learn more about how to use `viem` with Hardhat, read [this guide](./learn-more/using-viem.md).
+
+### Solidity vs TypeScript tests
+
+Solidity tests run directly on the EVM and are great for unit tests. They execute in a controlled environment, making them fast and deterministic. They also have access to test-related EVM extensions, normally called cheatcodes, which allow you to build complex tests in Solidity.
+
+TypeScript tests, on the other hand, use a fully-simulated local blockchain and interact with it through JSON-RPC. This allows you to write more complex or end-to-end tests using the full power of a general-purpose programming language and a realistic blockchain simulation. You can use any Ethereum TypeScript library, like [viem](https://viem.sh/) or [ethers.js](https://docs.ethers.org/v5/) to write your tests.
+
+Use Solidity when you want low-level, efficient, EVM-native tests. Use TypeScript when you want richer tooling, more flexible assertions, or to test blockchain-level interactions, like workflows involving multiple transactions.
 
 ## Writing scripts to interact with the network
 

--- a/src/content/hardhat3-alpha/learn-more/_dirinfo.yaml
+++ b/src/content/hardhat3-alpha/learn-more/_dirinfo.yaml
@@ -9,6 +9,8 @@ order:
     href: /deploying-contracts
   - title: Configuring the compiler
     href: /configuring-the-compiler
+  - title: Configuration variables
+    href: /configuration-variables
   - title: Differences with Hardhat 2
     href: /comparison
   - title: Alpha version limitations

--- a/src/content/hardhat3-alpha/learn-more/configuration-variables.md
+++ b/src/content/hardhat3-alpha/learn-more/configuration-variables.md
@@ -223,6 +223,28 @@ Besides `keystore set`, Hardhat provides several other tasks to help you manage 
 
   ::::
 
+- To find the path to the keystore file, use `keystore path`:
+
+  ::::tabsgroup{options=npm,pnpm}
+
+  :::tab{value=npm}
+
+  ```bash
+  npx hardhat keystore path
+  ```
+
+  :::
+
+  :::tab{value=pnpm}
+
+  ```bash
+  pnpm hardhat keystore path
+  ```
+
+  :::
+
+  ::::
+
 <!-- ## Combining environment and encrypted variables
 
 The `hardhat-keystore` plugin extends how configuration variables are resolved, but it doesn’t replace their default behavior. Hardhat still looks for environment variables first, and only falls back to the keystore if the variable isn’t set in the environment. This makes it easy to mix and override values depending on your workflow.
@@ -252,33 +274,3 @@ SEPOLIA_RPC_URL=https://temporary-url.example pnpm hardhat test
 This lets you test with a different provider without changing or deleting the encrypted value.
 
 Another use case is **defining a variable exclusively through environment variables**, without using the keystore at all. This is useful in environments like CI runners. Since environment variables are always checked first, you don’t need to change anything in your config for this to work. -->
-
-## Under the hood
-
-The location of the encrypted keystore file depends on your operating system. You can see where it’s stored by running any keystore task with the `--verbose` flag. For example:
-
-::::tabsgroup{options=npm,pnpm}
-
-:::tab{value=npm}
-
-```bash
-npx hardhat keystore list --verbose
-```
-
-:::
-
-:::tab{value=pnpm}
-
-```bash
-pnpm hardhat keystore list --verbose
-```
-
-:::
-
-::::
-
-On Linux, this might print something like:
-
-```
-path to keystore file: /home/username/.config/hardhat-nodejs/keystore.json
-```

--- a/src/content/hardhat3-alpha/learn-more/configuration-variables.md
+++ b/src/content/hardhat3-alpha/learn-more/configuration-variables.md
@@ -1,0 +1,288 @@
+# How to use configuration variables and the keystore plugin
+
+Hardhat projects often need values that vary from one developer to another or that shouldn’t be committed to source control, like private keys or RPC URLs with API keys. To manage this securely and flexibly, Hardhat supports configuration variables. This guide covers how to use them and how to securely store sensitive values with the `hardhat-keystore` plugin.
+
+## Using configuration variables
+
+A common example of a value that you don’t want to hardcode is an RPC URL that includes an API key, such as one from [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/):
+
+```tsx
+const config = {
+  networks: {
+    sepolia: {
+      url: "https://eth-sepolia.g.alchemy.com/v2/ABC123...",
+      // ...
+    },
+  },
+};
+```
+
+To solve this, Hardhat lets you use **configuration variables**. These are placeholders that get replaced with actual values at runtime:
+
+```tsx
+import { configVariable } from "hardhat/config";
+
+const config = {
+  networks: {
+    sepolia: {
+      url: configVariable("SEPOLIA_RPC_URL"),
+      // ...
+    },
+  },
+};
+```
+
+This way, the actual value is never committed to your repository.
+
+By default, configuration variables get their values from environment variables. For example, in the snippet above, Hardhat will look for an environment variable named `SEPOLIA_RPC_URL` when it needs the value. You can define it inline when running a task:
+
+::::tabsgroup{options=npm,pnpm}
+
+:::tab{value=npm}
+
+```bash
+SEPOLIA_RPC_URL='https://eth-sepolia.g.alchemy.com/v2/ABC123...' npx hardhat test
+```
+
+:::
+
+:::tab{value=pnpm}
+
+```bash
+SEPOLIA_RPC_URL='https://eth-sepolia.g.alchemy.com/v2/ABC123...' pnpm hardhat test
+```
+
+:::
+
+::::
+
+But configuration variables are **extensible**: plugins can define alternative ways to obtain their values. This means you’re not limited to environment variables—you can plug in other sources, such as encrypted storage, cloud secrets managers, or any custom logic.
+
+Another important detail is that configuration variables are **lazy**, meaning that they’re only resolved when actually needed. For example, if you define a network that uses a configuration variable for its RPC URL, and that variable isn’t set, it won’t cause any issues unless you actually try to connect to that network. Running tasks like `compile`, or executing tests that don’t use the network, will work just fine.
+
+## The `hardhat-keystore` plugin
+
+In the previous section we said that configuration variables are resolved from environment variables by default. This works, but it comes with some downsides. For example, if you type secrets directly into your shell, they’ll end up in your shell history. You also have to re-set them every time, or rely on tools like `.env` files, which have their own limitations.
+
+To address these issues, Hardhat provides an official plugin called `hardhat-keystore`. It lets you store sensitive values in an encrypted file and use them as configuration variables, without having to type them every time or commit them to disk in plain text.
+
+### Setup
+
+The `hardhat-keystore` plugin is part of the example project, but it can also be installed manually:
+
+1. Install the plugin:
+
+   ::::tabsgroup{options=npm,pnpm}
+
+   :::tab{value=npm}
+
+   ```bash
+   npm install --save-dev @nomicfoundation/hardhat-keystore@next
+   ```
+
+   :::
+
+   :::tab{value=pnpm}
+
+   ```bash
+   pnpm install --save-dev @nomicfoundation/hardhat-keystore@next
+   ```
+
+   :::
+
+   ::::
+
+2. Add it to the list of plugins in your Hardhat configuration:
+
+   ```tsx
+   import hardhatKeystore from "@nomicfoundation/hardhat-keystore";
+
+   const config: HardhatUserConfig = {
+     plugins: [
+       hardhatKeystore,
+       // ...other plugins...
+     ],
+     // ...other config...
+   };
+
+   export default config;
+   ```
+
+### Using the keystore
+
+To store an encrypted secret, use the `keystore set` task. For example, to store an Alchemy API key under the name `SEPOLIA_RPC_URL`, run:
+
+::::tabsgroup{options=npm,pnpm}
+
+:::tab{value=npm}
+
+```bash
+npx hardhat keystore set SEPOLIA_RPC_URL
+```
+
+:::
+
+:::tab{value=pnpm}
+
+```bash
+pnpm hardhat keystore set SEPOLIA_RPC_URL
+```
+
+:::
+
+::::
+
+When you run this task for the first time, you’ll be prompted to create a password for your keystore. After that, every time you add a new value, you’ll need to enter that password to confirm the operation. The secret is then encrypted in a file in your home directory.
+
+Once a value is stored in the keystore, you can use it in your configuration just like any other configuration variable. For example, if you stored an RPC URL under the name `SEPOLIA_RPC_URL`, you can reference it in exactly the same way we did above:
+
+```tsx
+import { configVariable } from "hardhat/config";
+
+const config = {
+  networks: {
+    sepolia: {
+      url: configVariable("SEPOLIA_RPC_URL"),
+      // ...
+    },
+  },
+};
+```
+
+When the configuration variable is needed, Hardhat will prompt you to enter the password and decrypt the value from the keystore.
+
+If the value isn’t needed—because the task doesn’t use it—you won’t be prompted at all. This means you can define encrypted variables freely without affecting tasks like compile or tests that don’t touch the network.
+
+## Managing encrypted variables
+
+Besides `keystore set`, Hardhat provides several other tasks to help you manage your encrypted configuration variables.
+
+- To view the value of a stored variable, use the `keystore get` task:
+
+  ::::tabsgroup{options=npm,pnpm}
+
+  :::tab{value=npm}
+
+  ```bash
+  npx hardhat keystore get SEPOLIA_RPC_URL
+  ```
+
+  :::
+
+  :::tab{value=pnpm}
+
+  ```bash
+  pnpm hardhat keystore get SEPOLIA_RPC_URL
+  ```
+
+  :::
+
+  ::::
+
+- To delete a configuration variable from the keystore, use `keystore delete`:
+
+  ::::tabsgroup{options=npm,pnpm}
+
+  :::tab{value=npm}
+
+  ```bash
+  npx hardhat keystore delete SEPOLIA_RPC_URL
+  ```
+
+  :::
+
+  :::tab{value=pnpm}
+
+  ```bash
+  pnpm hardhat keystore delete SEPOLIA_RPC_URL
+  ```
+
+  :::
+
+  ::::
+
+- To list all stored variable names, use `keystore list`:
+
+  ::::tabsgroup{options=npm,pnpm}
+
+  :::tab{value=npm}
+
+  ```bash
+  npx hardhat keystore list
+  ```
+
+  :::
+
+  :::tab{value=pnpm}
+
+  ```bash
+  pnpm hardhat keystore list
+  ```
+
+  :::
+
+  ::::
+
+## Combining environment and encrypted variables
+
+The `hardhat-keystore` plugin extends how configuration variables are resolved, but it doesn’t replace their default behavior. Hardhat still looks for environment variables first, and only falls back to the keystore if the variable isn’t set in the environment. This makes it easy to mix and override values depending on your workflow.
+
+One common use case is **overriding a keystore value with an environment variable**. For example, you might store a default value in the keystore but temporarily override it by setting an environment variable in your shell:
+
+::::tabsgroup{options=npm,pnpm}
+
+:::tab{value=npm}
+
+```bash
+SEPOLIA_RPC_URL=https://temporary-url.example npx hardhat test
+```
+
+:::
+
+:::tab{value=pnpm}
+
+```bash
+SEPOLIA_RPC_URL=https://temporary-url.example pnpm hardhat test
+```
+
+:::
+
+::::
+
+This lets you test with a different provider without changing or deleting the encrypted value.
+
+Another use case is **defining a variable exclusively through environment variables**, without using the keystore at all. This is useful in environments like CI runners. Since environment variables are always checked first, you don’t need to change anything in your config for this to work.
+
+## Under the hood
+
+The location of the encrypted keystore file depends on your operating system. You can see where it’s stored by running any keystore task with the `--verbose` flag. For example:
+
+::::tabsgroup{options=npm,pnpm}
+
+:::tab{value=npm}
+
+```bash
+npx hardhat keystore list --verbose
+```
+
+:::
+
+:::tab{value=pnpm}
+
+```bash
+pnpm hardhat keystore list --verbose
+```
+
+:::
+
+::::
+
+On Linux, this might print something like:
+
+```
+path to keystore file: /home/username/.config/hardhat-nodejs/keystore.json
+```
+
+<!--TODO: cryptography details -->
+
+<!-- TODO: how safe it is? -->

--- a/src/content/hardhat3-alpha/learn-more/configuration-variables.md
+++ b/src/content/hardhat3-alpha/learn-more/configuration-variables.md
@@ -223,7 +223,7 @@ Besides `keystore set`, Hardhat provides several other tasks to help you manage 
 
   ::::
 
-## Combining environment and encrypted variables
+<!-- ## Combining environment and encrypted variables
 
 The `hardhat-keystore` plugin extends how configuration variables are resolved, but it doesn’t replace their default behavior. Hardhat still looks for environment variables first, and only falls back to the keystore if the variable isn’t set in the environment. This makes it easy to mix and override values depending on your workflow.
 
@@ -251,7 +251,7 @@ SEPOLIA_RPC_URL=https://temporary-url.example pnpm hardhat test
 
 This lets you test with a different provider without changing or deleting the encrypted value.
 
-Another use case is **defining a variable exclusively through environment variables**, without using the keystore at all. This is useful in environments like CI runners. Since environment variables are always checked first, you don’t need to change anything in your config for this to work.
+Another use case is **defining a variable exclusively through environment variables**, without using the keystore at all. This is useful in environments like CI runners. Since environment variables are always checked first, you don’t need to change anything in your config for this to work. -->
 
 ## Under the hood
 

--- a/src/content/hardhat3-alpha/learn-more/configuration-variables.md
+++ b/src/content/hardhat3-alpha/learn-more/configuration-variables.md
@@ -282,7 +282,3 @@ On Linux, this might print something like:
 ```
 path to keystore file: /home/username/.config/hardhat-nodejs/keystore.json
 ```
-
-<!--TODO: cryptography details -->
-
-<!-- TODO: how safe it is? -->

--- a/src/content/hardhat3-alpha/learn-more/using-viem.md
+++ b/src/content/hardhat3-alpha/learn-more/using-viem.md
@@ -143,6 +143,27 @@ To do this, you need to configure Hardhat to compile the contract and generate a
 
 To learn how to do it, please read [this guide](./configuring-the-compiler.md#generating-artifacts-from-npm-dependencies).
 
+## Viem assertions
+
+The example project includes the `hardhat-viem-assertions` plugin, which helps you write expressive TypeScript tests in viem-based projects.
+
+This plugin adds an `assertions` property to the `viem` object, giving you utility functions to test contract behavior more easily. For example, the following test checks that calling a function emits the expected event:
+
+```typescript
+it("Should emit the Increment event when calling the inc() function", async function () {
+  const counter = await viem.deployContract("Counter");
+
+  await viem.assertions.emitWithArgs(
+    counter.write.inc(),
+    counter,
+    "Increment",
+    [1n]
+  );
+});
+```
+
+You can also assert that transactions revert (and why), or check that account balances change as expected.
+
 ## Type-safe contract interactions
 
 Viem has powerful typing capabilities, triggering compilation errors when you make mistakes like using the wrong type in a function argument or sending value to a non-payable function:


### PR DESCRIPTION
Depends on https://github.com/NomicFoundation/hardhat-website/pull/13

After adding the new paragraph, the intro to "Testing your contracts" was too long (a wall of text of five paragraphs). So I moved the explanation about the differences between the two types of tests to a new sub-section to the end.

I'm not 100% convinced about this, but I think it's better than having a long boring intro.