### PR TITLE
Replace curly apostrophes with straight ones

### DIFF
--- a/src/content/docs-landing/index.md
+++ b/src/content/docs-landing/index.md
@@ -9,7 +9,7 @@ description: Documentation about Hardhat, the Ethereum development environment
 
 This new major version introduces Solidity tests, a rewrite of performance critical components in Rust, adds multichain support across the board, implements OP Stack simulation, revamps the build system, modernizes our TS CLI and plugin system, and a lot more.
 
-Hardhat 3 is a complete overhaul. This is an alpha release and there’s still a lot of work ahead towards stability, but you can already take it for a spin. [Learn more.](/hardhat3-alpha)
+Hardhat 3 is a complete overhaul. This is an alpha release and there's still a lot of work ahead towards stability, but you can already take it for a spin. [Learn more.](/hardhat3-alpha)
 
 :::
 

--- a/src/content/hardhat-network-helpers/docs/overview.md
+++ b/src/content/hardhat-network-helpers/docs/overview.md
@@ -83,6 +83,6 @@ async function main() {
 
 ::::
 
-Since this is not a Hardhat plugin, you don’t need to import the whole package in your config. You can simply import each specific helper function where you need to use them.
+Since this is not a Hardhat plugin, you don't need to import the whole package in your config. You can simply import each specific helper function where you need to use them.
 
 For a full listing of all the helpers provided by this package, see [the reference documentation](./reference).

--- a/src/content/hardhat-runner/docs/advanced/building-plugins.md
+++ b/src/content/hardhat-runner/docs/advanced/building-plugins.md
@@ -12,7 +12,7 @@ Some examples of things you could achieve by creating a plugin are: running a li
 
 ## Extending the Hardhat Runtime Environment
 
-Let’s go through the process of creating a plugin that adds new functionality to the Hardhat Runtime Environment. By doing this, we make sure our new feature is available everywhere. This means your plugin users can access it from tasks, tests, scripts and the Hardhat console.
+Let's go through the process of creating a plugin that adds new functionality to the Hardhat Runtime Environment. By doing this, we make sure our new feature is available everywhere. This means your plugin users can access it from tasks, tests, scripts and the Hardhat console.
 
 The Hardhat Runtime Environment (HRE) is configured through a queue of extension functions that you can add to using the `extendEnvironment()` function. It receives one parameter which is a callback which will be executed after the HRE is initialized. If `extendEnvironment` is called multiple times, its callbacks will be executed in order.
 

--- a/src/content/hardhat-runner/docs/advanced/create-task.md
+++ b/src/content/hardhat-runner/docs/advanced/create-task.md
@@ -44,7 +44,7 @@ To get help for a specific task run: npx hardhat help [task]
 
 You can create additional tasks, which will appear in this list. For example, you might create a task to reset the state of a development environment, or to interact with your contracts, or to package your project.
 
-Let’s go through the process of creating one to interact with a smart contract.
+Let's go through the process of creating one to interact with a smart contract.
 
 Tasks in Hardhat are asynchronous JavaScript functions that get access to the [Hardhat Runtime Environment](../advanced/hardhat-runtime-environment.md), which exposes its configuration and parameters, as well as programmatic access to other tasks and any plugin objects that may have been injected.
 
@@ -86,13 +86,13 @@ pnpm add -D @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-network-he
 
 ::::
 
-Task creation code can go in `hardhat.config.js`, or whatever your configuration file is called. It’s a good place to create simple tasks. If your task is more complex, it's also perfectly valid to split the code into several files and `require` them from the configuration file.
+Task creation code can go in `hardhat.config.js`, or whatever your configuration file is called. It's a good place to create simple tasks. If your task is more complex, it's also perfectly valid to split the code into several files and `require` them from the configuration file.
 
-(If you’re writing a Hardhat plugin that adds a task, they can also be created from a separate npm package. Learn more about creating tasks through plugins in our [Building plugins section](../advanced/building-plugins.md).)
+(If you're writing a Hardhat plugin that adds a task, they can also be created from a separate npm package. Learn more about creating tasks through plugins in our [Building plugins section](../advanced/building-plugins.md).)
 
 **The configuration file is always executed on startup before anything else happens.** It's good to keep this in mind. We will load the Hardhat toolbox and add our task creation code to it.
 
-For this tutorial, we're going to create a task to get an account’s balance from the terminal. You can do this with the Hardhat’s config API, which is available in the global scope of `hardhat.config.js`:
+For this tutorial, we're going to create a task to get an account's balance from the terminal. You can do this with the Hardhat's config API, which is available in the global scope of `hardhat.config.js`:
 
 ```js
 require("@nomicfoundation/hardhat-toolbox");
@@ -129,7 +129,7 @@ AVAILABLE TASKS:
 To get help for a specific task run: npx hardhat help [task]
 ```
 
-Now let’s implement the functionality we want. We need to get the account address from the user. We can do this by adding a parameter to our task:
+Now let's implement the functionality we want. We need to get the account address from the user. We can do this by adding a parameter to our task:
 
 ```js
 task("balance", "Prints an account's balance")
@@ -154,7 +154,7 @@ balance: Prints an account's balance
 For global options help run: hardhat help
 ```
 
-Let’s now get the account’s balance. The [Hardhat Runtime Environment](../advanced/hardhat-runtime-environment.md) will be available in the global scope. By using Hardhat’s [ether.js plugin](https://github.com/NomicFoundation/hardhat/tree/main/packages/hardhat-ethers), which is included in the Hardhat Toolbox, we get access to an ethers.js instance:
+Let's now get the account's balance. The [Hardhat Runtime Environment](../advanced/hardhat-runtime-environment.md) will be available in the global scope. By using Hardhat's [ether.js plugin](https://github.com/NomicFoundation/hardhat/tree/main/packages/hardhat-ethers), which is included in the Hardhat Toolbox, we get access to an ethers.js instance:
 
 ```js
 task("balance", "Prints an account's balance")

--- a/src/content/hardhat-runner/docs/advanced/using-viem.md
+++ b/src/content/hardhat-runner/docs/advanced/using-viem.md
@@ -69,7 +69,7 @@ Viem also provides functionality for interacting with contracts, and `hardhat-vi
 
 Use the `hre.viem` object to get these helpers, similar to how clients are used. The next example shows how to get a contract instance and call one of its methods:
 
-1. Create a `MyToken.sol` file inside your project’s `contracts` directory:
+1. Create a `MyToken.sol` file inside your project's `contracts` directory:
 
    ```solidity
    // SPDX-License-Identifier: MIT
@@ -146,7 +146,7 @@ If you want to learn more about working with contracts, you can visit the [`hard
 
 ### Testing
 
-In this example, we’ll test the `MyToken` contract, covering scenarios like supply increase and expected operation reverts.
+In this example, we'll test the `MyToken` contract, covering scenarios like supply increase and expected operation reverts.
 
 1. Create a `test/my-token.ts` file:
 

--- a/src/content/hardhat-runner/docs/getting-started/index.md
+++ b/src/content/hardhat-runner/docs/getting-started/index.md
@@ -11,7 +11,7 @@ description: Getting started with Hardhat, a development environment to compile,
 
 This new major version introduces Solidity tests, a rewrite of performance critical components in Rust, adds multichain support across the board, implements OP Stack simulation, revamps the build system, modernizes our TS CLI and plugin system, and a lot more.
 
-Hardhat 3 is a complete overhaul. This is an alpha release and there’s still a lot of work ahead towards stability, but you can already take it for a spin. [Learn more.](/hardhat3-alpha)
+Hardhat 3 is a complete overhaul. This is an alpha release and there's still a lot of work ahead towards stability, but you can already take it for a spin. [Learn more.](/hardhat3-alpha)
 
 :::
 
@@ -108,7 +108,7 @@ $ npx hardhat init
   Quit
 ```
 
-Let’s create the JavaScript or TypeScript project and go through these steps to compile, test and deploy the sample contract. We recommend using TypeScript, but if you are not familiar with it just pick JavaScript.
+Let's create the JavaScript or TypeScript project and go through these steps to compile, test and deploy the sample contract. We recommend using TypeScript, but if you are not familiar with it just pick JavaScript.
 
 ### Running tasks
 

--- a/src/content/hardhat-runner/docs/guides/configuration-variables.md
+++ b/src/content/hardhat-runner/docs/guides/configuration-variables.md
@@ -27,7 +27,7 @@ Then the URL for the `sepolia` network will be formed with the configuration var
 
 :::warning
 
-Configuration variables are stored in plain text on your disk. Avoid using this feature for data you wouldn’t normally save in an unencrypted file. Run `npx hardhat vars path` to find the storage's file location.
+Configuration variables are stored in plain text on your disk. Avoid using this feature for data you wouldn't normally save in an unencrypted file. Run `npx hardhat vars path` to find the storage's file location.
 
 :::
 

--- a/src/content/hardhat-runner/docs/guides/test-contracts.md
+++ b/src/content/hardhat-runner/docs/guides/test-contracts.md
@@ -8,7 +8,7 @@ While this is our recommended test setup, Hardhat is flexible: you can customize
 
 ### Initial setup
 
-In this guide we’ll write some tests for the sample project. If you haven’t done it yet, go and [initialize it](./project-setup.md).
+In this guide we'll write some tests for the sample project. If you haven't done it yet, go and [initialize it](./project-setup.md).
 
 We recommend you [use TypeScript](./typescript.md) to get better autocompletion and catch possible errors earlier. This guide will assume you are using TypeScript, but you can click the tabs of the code examples to see the Javascript counterpart.
 
@@ -18,7 +18,7 @@ The setup includes some example tests in the `test/Lock.ts` file, but ignore the
 
 In the following sections we'll write some tests for the `Lock` contract that comes with the sample project. If you haven't read it yet, please take a look at the `contracts/Lock.sol` file.
 
-For our first test we’ll deploy the `Lock` contract and assert that the unlock time returned by the `unlockTime()` getter is the same one that we passed in the constructor:
+For our first test we'll deploy the `Lock` contract and assert that the unlock time returned by the `unlockTime()` getter is the same one that we passed in the constructor:
 
 ::::tabsgroup{options="TypeScript,JavaScript"}
 
@@ -80,13 +80,13 @@ describe("Lock", function () {
 
 First we import the things we are going to use: the [`expect`](https://www.chaijs.com/api/bdd/) function from `chai` to write our assertions, the [Hardhat Runtime Environment](../advanced/hardhat-runtime-environment.md) (`hre`), and the [network helpers](/hardhat-network-helpers) to interact with the Hardhat Network. After that we use the `describe` and `it` functions, which are global Mocha functions used to describe and group your tests. (You can read more about Mocha [here](https://mochajs.org/#getting-started).)
 
-The test itself is what’s inside the callback argument to the `it` function. First we set the values for the amount we want to lock (in [wei](https://ethereum.org/en/glossary/#wei)) and the unlock time. For the latter we use [`time.latest`](</hardhat-network-helpers/docs/reference#latest()>), a network helper that returns the timestamp of the last mined block. Then we deploy the contract itself: we call `ethers.deployContract` with the name of the contract we want to deploy and an array of constructor arguments that has the unlock time. We also pass an object with the transaction parameters. This is optional, but we'll use it to send some ETH by setting its `value` field.
+The test itself is what's inside the callback argument to the `it` function. First we set the values for the amount we want to lock (in [wei](https://ethereum.org/en/glossary/#wei)) and the unlock time. For the latter we use [`time.latest`](</hardhat-network-helpers/docs/reference#latest()>), a network helper that returns the timestamp of the last mined block. Then we deploy the contract itself: we call `ethers.deployContract` with the name of the contract we want to deploy and an array of constructor arguments that has the unlock time. We also pass an object with the transaction parameters. This is optional, but we'll use it to send some ETH by setting its `value` field.
 
 Finally, we check that the value returned by the `unlockTime()` [getter](https://docs.soliditylang.org/en/v0.8.13/contracts.html#getter-functions) in the contract matches the value that we used when we deployed it. Since all the functions on a contract are async, we have to use the `await` keyword to get its value; otherwise, we would be comparing a promise with a number and this would always fail.
 
 ### Testing a function that reverts
 
-In the previous test we checked that a getter function returned the correct value. This was a read-only function that can be called without paying a fee and without any risk. Other functions, however, can modify the state of the contract, like the `withdraw` function in the `Lock` contract. This means that we want some pre-conditions to be met for this function to be called successfully. If you look at its first lines you’ll see a couple of `require` checks for that purpose:
+In the previous test we checked that a getter function returned the correct value. This was a read-only function that can be called without paying a fee and without any risk. Other functions, however, can modify the state of the contract, like the `withdraw` function in the `Lock` contract. This means that we want some pre-conditions to be met for this function to be called successfully. If you look at its first lines you'll see a couple of `require` checks for that purpose:
 
 ```solidity
 function withdraw() public {
@@ -94,7 +94,7 @@ function withdraw() public {
   require(msg.sender == owner, "You aren't the owner");
 ```
 
-The first statement checks that the unlock time has been reached, and the second one checks that the address calling the contract is its owner. Let’s start by writing a test for the first pre-condition:
+The first statement checks that the unlock time has been reached, and the second one checks that the address calling the contract is its owner. Let's start by writing a test for the first pre-condition:
 
 ```ts
 it("Should revert with the right error if called too soon", async function () {
@@ -104,13 +104,13 @@ it("Should revert with the right error if called too soon", async function () {
 });
 ```
 
-In the previous test we used `.to.equal`, which is part of Chai and is used to compare two values. Here we are using [`.to.be.revertedWith`](/hardhat-chai-matchers/docs/reference#.revertedwith), which asserts that a transaction reverts, and that the reason string of the revert is equal to the given string. The `.to.be.revertedWith` matcher is not part of Chai itself; instead, it’s added by the [Hardhat Chai Matchers](/hardhat-chai-matchers) plugin, which is included in the sample project we are using.
+In the previous test we used `.to.equal`, which is part of Chai and is used to compare two values. Here we are using [`.to.be.revertedWith`](/hardhat-chai-matchers/docs/reference#.revertedwith), which asserts that a transaction reverts, and that the reason string of the revert is equal to the given string. The `.to.be.revertedWith` matcher is not part of Chai itself; instead, it's added by the [Hardhat Chai Matchers](/hardhat-chai-matchers) plugin, which is included in the sample project we are using.
 
 Notice that in the previous test we wrote `expect(await ...)` but now we are doing `await expect(...)`. In the first case we were comparing two values in a synchronous way; the inner await is just there to wait for the value to be retrieved. In the second case, the whole assertion is async because it has to wait until the transaction is mined. This means that the `expect` call returns a promise that we have to await.
 
 ### Manipulating the time of the network
 
-We are deploying our `Lock` contract with an unlock time of one year. If we want to write a test that checks what happens after the unlock time has passed, we can’t wait that amount of time. We could use a shorter unlock time, like 5 seconds, but that’s a less realistic value and it's still a long time to wait in a test.
+We are deploying our `Lock` contract with an unlock time of one year. If we want to write a test that checks what happens after the unlock time has passed, we can't wait that amount of time. We could use a shorter unlock time, like 5 seconds, but that's a less realistic value and it's still a long time to wait in a test.
 
 The solution is to simulate the passage of time. This can be done with the [`time.increaseTo`](</hardhat-network-helpers/docs/reference#increaseto(timestamp)>) network helper, which mines a new block with the given timestamp:
 

--- a/src/content/hardhat-runner/docs/supporter-guides/oracles.md
+++ b/src/content/hardhat-runner/docs/supporter-guides/oracles.md
@@ -78,7 +78,7 @@ contract PriceConsumerV3 {
 
 Randomness in computer systems, especially on blockchains, is challenging to achieve because general-purpose blockchains like Ethereum do not have inherent randomness. Another problem is the public nature of blockchain technology which makes finding a secure source of entropy difficult. Almost any mechanism of generating on-chain randomness using Solidity is vulnerable to [MEV attacks](https://ethereum.org/en/developers/docs/mev/).
 
-It is possible to generate the random value off-chain and send it on-chain, but doing so imposes high trust requirements on users. They must believe the value was truly generated via unpredictable mechanisms and wasn’t altered in transit.
+It is possible to generate the random value off-chain and send it on-chain, but doing so imposes high trust requirements on users. They must believe the value was truly generated via unpredictable mechanisms and wasn't altered in transit.
 
 Oracles designed for off-chain computation solve this problem by securely generating random outcomes off-chain that they broadcast on-chain along with cryptographic proofs attesting to the unpredictability of the process. An example is Chainlink VRF (Verifiable Random Function), which is a provably-fair and verifiable source of randomness designed for smart contracts. Smart contract developers can use Chainlink VRF as a tamper-proof random number generation (RNG) to build smart contracts for any applications which rely on unpredictable outcomes:
 

--- a/src/content/hardhat3-alpha/index.md
+++ b/src/content/hardhat3-alpha/index.md
@@ -16,7 +16,7 @@ This guide will walk you through the installation of our recommended setup, but 
 
 :::
 
-To get started with Hardhat 3, you’ll need [Node.js](https://nodejs.org/) v22 or later installed on your system, along with a package manager such as [npm](https://www.npmjs.com/) or [pnpm](https://pnpm.io/).
+To get started with Hardhat 3, you'll need [Node.js](https://nodejs.org/) v22 or later installed on your system, along with a package manager such as [npm](https://www.npmjs.com/) or [pnpm](https://pnpm.io/).
 
 First, create a new directory for your project:
 
@@ -55,7 +55,7 @@ Using the defaults will:
 2. Use the example project that includes the [Node.js test runner](https://nodejs.org/api/test.html) and [viem](https://viem.sh/).
 3. Automatically install all the required dependencies.
 
-After the setup is complete, you’ll have a fully working Hardhat 3 project with everything you need to get started. Run the Hardhat help to verify the project was set up correctly:
+After the setup is complete, you'll have a fully working Hardhat 3 project with everything you need to get started. Run the Hardhat help to verify the project was set up correctly:
 
 ::::tabsgroup{options=npm,pnpm}
 
@@ -100,7 +100,7 @@ scripts
 └── send-op-tx.ts
 ```
 
-Here’s a quick overview of these files and directories:
+Here's a quick overview of these files and directories:
 
 - `hardhat.config.ts`: The main configuration file for your project. It defines settings like the Solidity compiler version, network configurations, and the plugins and tasks your project uses.
 
@@ -110,7 +110,7 @@ Here’s a quick overview of these files and directories:
 
 - `ignition`: Holds your [Hardhat Ignition](https://hardhat.org/ignition) deployment modules, which describe how your contracts should be deployed.
 
-- `scripts`: A place for any custom scripts that interact with your contracts or automate parts of your workflow. Scripts have full access to Hardhat’s runtime and can use plugins, connect to networks, deploy contracts, and more.
+- `scripts`: A place for any custom scripts that interact with your contracts or automate parts of your workflow. Scripts have full access to Hardhat's runtime and can use plugins, connect to networks, deploy contracts, and more.
 
 ## Writing a smart contract
 
@@ -269,7 +269,7 @@ function test_IncByZero() public {
 }
 ```
 
-Then run the last command again and you’ll get a stack-trace along with the test failure:
+Then run the last command again and you'll get a stack-trace along with the test failure:
 
 ```
 Failure (1): test_IncByZero()

--- a/src/content/hardhat3-alpha/learn-more/comparison.md
+++ b/src/content/hardhat3-alpha/learn-more/comparison.md
@@ -28,7 +28,7 @@ Hardhat 3 embraces modern JavaScript by using [ECMAScript Modules (ESM)](https:/
 
 In Hardhat 2, JavaScript tests are always run with a bundled version of Mocha. In Hardhat 3, the test runner is just another plugin and you can choose which one to use.
 
-Hardhat 3 provides official plugins for running tests: one for Mocha and one for [Node.js’s built-in test runner](https://nodejs.org/api/test.html) The recommended option is the Node.js test runner, because it's fast and has no external dependencies.
+Hardhat 3 provides official plugins for running tests: one for Mocha and one for [Node.js's built-in test runner](https://nodejs.org/api/test.html) The recommended option is the Node.js test runner, because it's fast and has no external dependencies.
 
 ## Declarative Configuration
 

--- a/src/content/hardhat3-alpha/learn-more/configuring-the-compiler.md
+++ b/src/content/hardhat3-alpha/learn-more/configuring-the-compiler.md
@@ -78,7 +78,7 @@ For example, given the configuration above:
 
 ## Overriding configured compilers
 
-Some projects need to compile specific files using a different compiler version than Hardhat’s default choice. You can handle this with the `overrides` property:
+Some projects need to compile specific files using a different compiler version than Hardhat's default choice. You can handle this with the `overrides` property:
 
 ```typescript
 solidity: {
@@ -127,7 +127,7 @@ TODO—blocked until dependency resolution is finalized.
 
 ## Generating artifacts from npm dependencies
 
-By default, Hardhat generates compilation artifacts for all the contracts in your project, but not for those in the project’s npm dependencies. If you want to generate artifacts for a specific file in a dependency, you can use the `dependenciesToCompile` property:
+By default, Hardhat generates compilation artifacts for all the contracts in your project, but not for those in the project's npm dependencies. If you want to generate artifacts for a specific file in a dependency, you can use the `dependenciesToCompile` property:
 
 ```typescript
 solidity: {
@@ -138,7 +138,7 @@ solidity: {
 },
 ```
 
-Artifacts can be used to deploy contracts or to obtain their ABIs, among other things. For example, once you’ve configured Hardhat to generate artifacts for `some-dependency/contracts/SomeContract.sol`, you can use that contract in a TypeScript test:
+Artifacts can be used to deploy contracts or to obtain their ABIs, among other things. For example, once you've configured Hardhat to generate artifacts for `some-dependency/contracts/SomeContract.sol`, you can use that contract in a TypeScript test:
 
 ```typescript
 const someContract = await viem.deployContract("SomeContract");

--- a/src/content/hardhat3-alpha/learn-more/solidity-tests.md
+++ b/src/content/hardhat3-alpha/learn-more/solidity-tests.md
@@ -4,9 +4,9 @@ prev: true
 
 # Solidity Tests
 
-Hardhat 3 introduces support for Solidity tests, alongside the existing TypeScript-based test framework. This feature wasn’t feasible in Hardhat 2 due to technical limitations, but with the architectural improvements in Hardhat 3, we’re able to deliver Solidity testing with the quality you’ve come to expect from Hardhat.
+Hardhat 3 introduces support for Solidity tests, alongside the existing TypeScript-based test framework. This feature wasn't feasible in Hardhat 2 due to technical limitations, but with the architectural improvements in Hardhat 3, we're able to deliver Solidity testing with the quality you've come to expect from Hardhat.
 
-Hardhat’s Solidity testing framework is compatible with the Dapptools-style Solidity tests, refined and popularized by Foundry. With this feature, you can write unit tests, fuzz tests, and invariant tests in Solidity, and leverage many of the Foundry-inspired cheatcodes you may already know. We designed Hardhat's Solidity tests to be as similar as possible to Foundry’s, minimizing unnecessary fragmentation in the developer community.
+Hardhat's Solidity testing framework is compatible with the Dapptools-style Solidity tests, refined and popularized by Foundry. With this feature, you can write unit tests, fuzz tests, and invariant tests in Solidity, and leverage many of the Foundry-inspired cheatcodes you may already know. We designed Hardhat's Solidity tests to be as similar as possible to Foundry's, minimizing unnecessary fragmentation in the developer community.
 
 That said, there are some key differences in how Hardhat handles Solidity tests compared to Foundry. These differences are detailed in a section below.
 
@@ -24,8 +24,8 @@ Moreover, multichain workflows (a major feature of Hardhat 3) will eventually ex
 
 While Hardhat and Foundry share many similarities in their Solidity testing frameworks, there are a few differences:
 
-1. `testFail` behavior. Foundry’s testFail prefix indicates that the test passes only if the transaction reverts. In Hardhat, this is considered an anti-pattern because it is less explicit than using revert-expectation cheatcodes like vm.expectRevert. Hardhat does not support testFail by default but provides an opt-in mechanism for teams migrating legacy tests.
+1. `testFail` behavior. Foundry's testFail prefix indicates that the test passes only if the transaction reverts. In Hardhat, this is considered an anti-pattern because it is less explicit than using revert-expectation cheatcodes like vm.expectRevert. Hardhat does not support testFail by default but provides an opt-in mechanism for teams migrating legacy tests.
 2. No Inline Configuration via NatSpec. Unlike Foundry, Hardhat does not support configuring tests inline using NatSpec comments. Test configuration must be handled programmatically in your test files.
 3. Unsupported Scripting Cheatcodes Foundry includes cheatcodes that facilitate scripting, such as startBroadcast and stopBroadcast. These are not currently supported in Hardhat since they are beyond the scope of its testing-focused architecture.
-4. No Fixture Support Foundry's fixture cheatcodes are not compatible with Hardhat’s approach to test isolation. Instead, Hardhat relies on programmatic test setup and fixtures defined in JavaScript/TypeScript.
-5. Cheatcodes: getCode and getDeployedCode Foundry’s getCode and getDeployedCode cheatcodes are not supported in Hardhat because they conflict with how Hardhat handles runtime deployments and its dynamic testing environment.
+4. No Fixture Support Foundry's fixture cheatcodes are not compatible with Hardhat's approach to test isolation. Instead, Hardhat relies on programmatic test setup and fixtures defined in JavaScript/TypeScript.
+5. Cheatcodes: getCode and getDeployedCode Foundry's getCode and getDeployedCode cheatcodes are not supported in Hardhat because they conflict with how Hardhat handles runtime deployments and its dynamic testing environment.

--- a/src/content/hardhat3-alpha/learn-more/using-viem.md
+++ b/src/content/hardhat3-alpha/learn-more/using-viem.md
@@ -4,7 +4,7 @@
 
 ## Setup
 
-If you have already initialized a viem-based project using `hardhat --init`, you don’t need to do anything else.
+If you have already initialized a viem-based project using `hardhat --init`, you don't need to do anything else.
 
 If you want to add the plugin manually:
 
@@ -118,7 +118,7 @@ const counter = await viem.deployContract("Counter", [10n], {
 });
 ```
 
-The `deployContract` function waits until the contract is deployed. If you just want to send the deployment without waiting until it’s mined, you can use `sendDeploymentTransaction`:
+The `deployContract` function waits until the contract is deployed. If you just want to send the deployment without waiting until it's mined, you can use `sendDeploymentTransaction`:
 
 ```tsx
 const deploymentTx = await viem.sendDeploymentTransaction("Counter", [10n], {
@@ -161,13 +161,13 @@ When using viem on its own, you need to pass an ABI to get contract instances wi
 
 ### Troubleshooting contract type errors
 
-Contract types are updated when the project is compiled. If you are getting a compilation error that you don’t expect, make sure you’ve run `hardhat compile`.
+Contract types are updated when the project is compiled. If you are getting a compilation error that you don't expect, make sure you've run `hardhat compile`.
 
 Note that VSCode may not always pick up the type updates automatically. If you are still getting unexpected TypeScript errors after compiling the project, open the [Command Palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) and run `TypeScript: Reload Project`.
 
 ## Using viem as a module
 
-The `viem` object in the connection only includes functionality added by the `hardhat-viem` plugin. To use viem’s own functionality, import it from the `viem` module:
+The `viem` object in the connection only includes functionality added by the `hardhat-viem` plugin. To use viem's own functionality, import it from the `viem` module:
 
 ```tsx
 import { keccak256 } from "viem";

--- a/src/content/hardhat3-alpha/learn-more/writing-solidity-tests.md
+++ b/src/content/hardhat3-alpha/learn-more/writing-solidity-tests.md
@@ -1,12 +1,12 @@
 # Writing unit tests in Solidity
 
-Hardhat supports writing tests in both TypeScript and Solidity. TypeScript is typically used for higher-level integration tests, whereas Solidity is better suited for unit tests. This guide explains how to add Solidity tests to a Hardhat project, run them, and configure how they are executed. It assumes familiarity with Solidity tests and isn’t meant to serve as an introduction to them.
+Hardhat supports writing tests in both TypeScript and Solidity. TypeScript is typically used for higher-level integration tests, whereas Solidity is better suited for unit tests. This guide explains how to add Solidity tests to a Hardhat project, run them, and configure how they are executed. It assumes familiarity with Solidity tests and isn't meant to serve as an introduction to them.
 
 ## Writing Solidity tests
 
-A Solidity file is considered a test file if it’s inside the `test/` directory, or if it’s inside the `contracts/` directory and ends with `.t.sol`. Both of these directories can be changed in your Hardhat configuration, but these are the defaults.
+A Solidity file is considered a test file if it's inside the `test/` directory, or if it's inside the `contracts/` directory and ends with `.t.sol`. Both of these directories can be changed in your Hardhat configuration, but these are the defaults.
 
-If a contract in a test file has at least a function that starts with `test`, it’s considered a test contract. When the tests are run, Hardhat deploys every test contract and calls each of its test functions.
+If a contract in a test file has at least a function that starts with `test`, it's considered a test contract. When the tests are run, Hardhat deploys every test contract and calls each of its test functions.
 
 For example, if you have a `contracts/CounterTest.t.sol` or `test/CounterTest.sol` file with the following contract:
 
@@ -36,7 +36,7 @@ contract CounterTest {
 
 ### Assertion libraries
 
-In the previous example, the error message doesn’t show the actual value of `by` that made the test fail. That’s because interpolating the value into the string isn’t straightforward in Solidity. To get better error messages, plus other useful functionality, you can use an assertion library like [forge-std](https://github.com/foundry-rs/forge-std).
+In the previous example, the error message doesn't show the actual value of `by` that made the test fail. That's because interpolating the value into the string isn't straightforward in Solidity. To get better error messages, plus other useful functionality, you can use an assertion library like [forge-std](https://github.com/foundry-rs/forge-std).
 
 To use `forge-std` in a Hardhat project, first install it:
 
@@ -194,7 +194,7 @@ solidityTest: {
 },
 ```
 
-It’s also possible to modify the execution environment of the tests. For example, you can modify the address that is returned by `msg.sender`:
+It's also possible to modify the execution environment of the tests. For example, you can modify the address that is returned by `msg.sender`:
 
 ```typescript
 solidityTest: {

--- a/src/content/ignition/docs/advanced/migrating.md
+++ b/src/content/ignition/docs/advanced/migrating.md
@@ -4,7 +4,7 @@ This guide will walk you through migrating your Hardhat project to Hardhat Ignit
 
 ## Installing Hardhat Ignition
 
-To get started, we’ll uninstall the `hardhat-deploy` plugin and install the Hardhat Ignition one by executing the following steps:
+To get started, we'll uninstall the `hardhat-deploy` plugin and install the Hardhat Ignition one by executing the following steps:
 
 1. Remove the `hardhat-deploy` packages from your project:
 
@@ -66,7 +66,7 @@ To get started, we’ll uninstall the `hardhat-deploy` plugin and install the Ha
 
    ::::
 
-3. Update the project’s `hardhat.config` file to remove `hardhat-deploy` and `hardhat-deploy-ethers` and instead import Hardhat Ignition:
+3. Update the project's `hardhat.config` file to remove `hardhat-deploy` and `hardhat-deploy-ethers` and instead import Hardhat Ignition:
 
    ::::tabsgroup{options="typescript,javascript"}
 
@@ -96,14 +96,14 @@ To get started, we’ll uninstall the `hardhat-deploy` plugin and install the Ha
 
 `hardhat-deploy` represents contract deployments as JavaScript or TypeScript files under the `./deploy/` folder. Hardhat Ignition follows a similar pattern with deployments encapsulated as modules; these are JS/TS files stored under the `./ignition/modules` directory. Each `hardhat-deploy` deploy file will be converted or merged into a Hardhat Ignition module.
 
-Let’s first create the required folder structure under the root of your project:
+Let's first create the required folder structure under the root of your project:
 
 ```sh
 mkdir ignition
 mkdir ignition/modules
 ```
 
-Now, let’s work through converting a simple `hardhat-deploy` script for this example `Token` contract:
+Now, let's work through converting a simple `hardhat-deploy` script for this example `Token` contract:
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -249,7 +249,7 @@ The conversion to an Ignition module can be tested by running the module against
 npx hardhat ignition deploy ./ignition/modules/Token.ts
 ```
 
-Which, if working correctly, will output the contract’s deployed address:
+Which, if working correctly, will output the contract's deployed address:
 
 ```
 You are running Hardhat Ignition against an in-process instance of Hardhat Network.
@@ -273,7 +273,7 @@ To learn more, check out the detailed [guide on writing Hardhat Ignition modules
 
 ## Migrating tests that rely on hardhat-deploy fixtures
 
-Let’s go over the process of rewriting Hardhat tests that rely on `hardhat-deploy` fixture functionality. Using `hardhat-deploy`, calls to `fixture()` deploy everything under the `./deploy` and create a snapshot in the in-memory Hardhat node at the end of the first run. Subsequent calls to `fixture()` revert to the saved snapshot, avoiding rerunning the deployment transactions and thus saving time.
+Let's go over the process of rewriting Hardhat tests that rely on `hardhat-deploy` fixture functionality. Using `hardhat-deploy`, calls to `fixture()` deploy everything under the `./deploy` and create a snapshot in the in-memory Hardhat node at the end of the first run. Subsequent calls to `fixture()` revert to the saved snapshot, avoiding rerunning the deployment transactions and thus saving time.
 
 To do this, `hardhat-deploy-ethers` enhances the Hardhat `ethers` object with a `getContract` method that will return contract instances from the fixture snapshot.
 

--- a/src/content/ignition/docs/guides/creating-modules.md
+++ b/src/content/ignition/docs/guides/creating-modules.md
@@ -148,7 +148,7 @@ The first parameter is the `Future` object, whose execution results in the event
 
 You can also provide as a fourth parameter an object with options, which can contain:
 
-- `emitter`: A `Future` representing the contract instance that **directly emits** the event. This defaults to the `Future` you pass as first argument, but they’re not always the same. A `Future` can be executed and indirectly lead to an event emission by calling other contracts during its execution, which then directly emit the event.
+- `emitter`: A `Future` representing the contract instance that **directly emits** the event. This defaults to the `Future` you pass as first argument, but they're not always the same. A `Future` can be executed and indirectly lead to an event emission by calling other contracts during its execution, which then directly emit the event.
 
 - `eventIndex`: If the are multiple events with the same name emitted by the `emitter`, you can use this parameter to pick one of them. It defaults to `0`.
 

--- a/src/content/tutorial/debugging-with-hardhat-network.md
+++ b/src/content/tutorial/debugging-with-hardhat-network.md
@@ -51,7 +51,7 @@ $ npx hardhat test
 Transferring from 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 to 0x70997970c51812dc3a010c7d01b50e0d17dc79c8 50 tokens
 Transferring from 0x70997970c51812dc3a010c7d01b50e0d17dc79c8 to 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc 50 tokens
       ✓ Should transfer tokens between accounts (373ms)
-      ✓ Should fail if sender doesn’t have enough tokens
+      ✓ Should fail if sender doesn't have enough tokens
 Transferring from 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 to 0x70997970c51812dc3a010c7d01b50e0d17dc79c8 50 tokens
 Transferring from 0x70997970c51812dc3a010c7d01b50e0d17dc79c8 to 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc 50 tokens
       ✓ Should update balances after transfers (187ms)

--- a/src/content/tutorial/deploying-to-a-live-network.md
+++ b/src/content/tutorial/deploying-to-a-live-network.md
@@ -53,7 +53,7 @@ TokenModule#Token - 0x5FbDB2315678afecb367f032d93F642f64180aa3
 
 ## Deploying to remote networks
 
-To deploy to a remote network such as mainnet or any testnet, you need to add a `network` entry to your `hardhat.config.js` file. We’ll use Sepolia for this example, but you can add any network. For key storage, utilize the `configuration variables`.
+To deploy to a remote network such as mainnet or any testnet, you need to add a `network` entry to your `hardhat.config.js` file. We'll use Sepolia for this example, but you can add any network. For key storage, utilize the `configuration variables`.
 
 :::tip
 

--- a/src/model/markdown.tsx
+++ b/src/model/markdown.tsx
@@ -103,6 +103,8 @@ export const withoutComments = (content: string) => {
   return content.replace(/<!--[\s\S]*?-->/gm, "");
 };
 
+export const normalizeApostrophes = (text: string) => text.replace(/’/g, "'");
+
 export const replacePlaceholders = (content: string) => {
   const recommendedSolcVersion = "0.8.28";
   const latestPragma = "^0.8.0";
@@ -227,8 +229,8 @@ export const generateTitleFromContent = (content: string) => {
 
 export const parseMdFile = (source: string) => {
   const { content, data } = matter(source);
-  const formattedContent = replacePlaceholders(
-    withoutComments(withInsertedCodeFromLinks(content))
+  const formattedContent = normalizeApostrophes(
+    replacePlaceholders(withoutComments(withInsertedCodeFromLinks(content)))
   );
 
   const tocTitle = data.title ?? generateTitleFromContent(formattedContent);


### PR DESCRIPTION
We have a mix of straight and curly apostrophes in our code. Is this important? Not really. Can I sleep at night now that I know this? Also not really.

I replaced the existing curly apostrophes, and added a function to replace them in runtime in the generated HTML.