### PR TITLE
chore: rename `node` to `nodejs` in aplha

### DIFF
--- a/src/content/hardhat3-alpha/index.md
+++ b/src/content/hardhat3-alpha/index.md
@@ -333,7 +333,7 @@ To run only your TypeScript tests, use the `test node` task:
 :::tab{value=npm}
 
 ```bash
-npx hardhat test node
+npx hardhat test nodejs
 ```
 
 :::
@@ -341,7 +341,7 @@ npx hardhat test node
 :::tab{value=pnpm}
 
 ```bash
-pnpm hardhat test node
+pnpm hardhat test nodejs
 ```
 
 :::

--- a/src/content/hardhat3-alpha/learn-more/whats-new.md
+++ b/src/content/hardhat3-alpha/learn-more/whats-new.md
@@ -254,7 +254,7 @@ To run the TypeScript tests in the project, execute the following command:
 :::tab{value=npm}
 
 ```
-npx hardhat test node
+npx hardhat test nodejs
 ```
 
 :::
@@ -262,7 +262,7 @@ npx hardhat test node
 :::tab{value=pnpm}
 
 ```
-pnpm hardhat test node
+pnpm hardhat test nodejs
 ```
 
 :::


### PR DESCRIPTION
The usage should now be `npx hardhat test nodejs`, to help disambiguate from `npx hardhat node`.