### PR TITLE
Warn about .reverted being the only matcher that is a property

### DIFF
--- a/src/content/hardhat-chai-matchers/docs/reference.md
+++ b/src/content/hardhat-chai-matchers/docs/reference.md
@@ -37,6 +37,10 @@ Assert that a transaction reverted for any reason, without checking the cause of
 await expect(token.transfer(address, 0)).to.be.reverted;
 ```
 
+:::warning
+This is the only matcher that has to be used as a property. The rest of the matchers below are functions and need to be called.
+:::
+
 ### `.revertedWith`
 
 Assert that a transaction reverted with a specific reason string:


### PR DESCRIPTION
Inspired by @shark0der wasting 90 minutes of his life because of this.