### PR TITLE
feat: add all Solidity test config options

### DIFF
--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -217,13 +217,13 @@ The following options are available for configuring Solidity tests:
 
 :::warning
 
-Giving write access to configuration files, source files or executables in a project is considered dangerous, because it can be used by malicious Solidity dependencies to escape the EVM sandbox. 
-It is therefore recommended to give write access to specific safe files only. 
+Giving write access to configuration files, source files or executables in a project is considered dangerous, because it can be used by malicious Solidity dependencies to escape the EVM sandbox.
+It is therefore recommended to give write access to specific safe files only.
 If write access to a directory is needed, please make sure that it doesn't contain configuration files, source files or executables neither in the top level directory, nor in any subdirectories.
 
 :::
 
-- `fsPermissions`:  An optional object to configure file system permissions for cheatcodes. Defaults to no permissions. Exact path matching is used for file permissions. Prefix matching is used for directory permissions.
+- `fsPermissions`: An optional object to configure file system permissions for cheatcodes. Defaults to no permissions. Exact path matching is used for file permissions. Prefix matching is used for directory permissions.
   - `readFile`: An array of file paths that can be read.
   - `writeFile`: An array of file paths that can be written.
   - `readWriteFile`: An array of file paths that can be both read and written.

--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -246,7 +246,7 @@ If write access to a directory is needed, please make sure that it doesn't conta
   - `forkBlockNumber`: Pins the block number for the global state fork.
   - `rpcEndpoints`: Map of RPC endpoints from chain name to RPC urls for fork cheat codes, e.g. `{ "optimism": "https://optimism.alchemyapi.io/v2/..." }`
 - `rpcStorageCaching`: What RPC endpoints are cached. Defaults to all.
-- `timeout`: The number of seconds to wait before `vm.prompt` reverts with a timeout. Defaults to 120.
+- `timeout`: The maximum time in milliseconds to wait for all the test suites to finish. Optional, defaults to none.
 - `fuzz`: Optional fuzz testing configuration object.
   - `failurePersistDir`: Optional path where fuzz failures are recorded and replayed if set.
   - `failurePersistFile`: Name of the file to record fuzz failures, defaults to `failures`.

--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -231,7 +231,7 @@ If write access to a directory is needed, please make sure that it doesn't conta
   - `dangerouslyWriteDirectory`: An array of directory paths. All files and directories inside these directories can be written. See warning above to understand why it's dangerous.
   - `dangerouslyReadWriteDirectory`: An array of directory paths. All files and directories inside these directories can be both read and written. See warning above to understand why it's dangerous.
 - `isolate`: Whether to enable isolation of calls. In isolation mode all top-level calls are executed as a separate transaction in a separate EVM context, enabling more precise gas accounting and transaction state changes. Defaults to false.
-- `ffi`: Whether or not to enable the ffi cheatcode. Warning: Enabling this cheatcode has security implications, as it allows tests to execute arbitrary programs on your computer. Defaults to false.
+- `ffi`: Whether or not to enable the ffi cheatcode. **Warning**: Enabling this cheatcode has security implications, as it allows tests to execute arbitrary programs on your computer. Defaults to false.
 - `allowInternalExpectRevert`: Allow expecting reverts with `expectRevert` at the same callstack depth as the test. Defaults to false.
 - `from`: The value of `msg.sender` in tests as hex string. Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.
 - `txOrigin`: The value of `tx.origin` in tests as hex string. Defaults to `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.

--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -228,8 +228,8 @@ If write access to a directory is needed, please make sure that it doesn't conta
   - `writeFile`: An array of file paths that can be written.
   - `readWriteFile`: An array of file paths that can be both read and written.
   - `readDirectory`: An array of directory paths. All files and directories inside these directories can be read.
-  - `dangerouslyWriteDirectory`: An array of directory paths. All files and directories inside these directories can be written. See warning above why it's dangerous.
-  - `dangerouslyReadWriteDirectory`: An array of directory paths. All files and directories inside these directories can be both read and written. See warning above why it's dangerous.
+  - `dangerouslyWriteDirectory`: An array of directory paths. All files and directories inside these directories can be written. See warning above to understand why it's dangerous.
+  - `dangerouslyReadWriteDirectory`: An array of directory paths. All files and directories inside these directories can be both read and written. See warning above to understand why it's dangerous.
 - `isolate`: Whether to enable isolation of calls. In isolation mode all top-level calls are executed as a separate transaction in a separate EVM context, enabling more precise gas accounting and transaction state changes. Defaults to false.
 - `ffi`: Whether or not to enable the ffi cheatcode. Warning: Enabling this cheatcode has security implications, as it allows tests to execute arbitrary programs on your computer. Defaults to false.
 - `allowInternalExpectRevert`: Allow expecting reverts with `expectRevert` at the same callstack depth as the test. Defaults to false.
@@ -241,7 +241,7 @@ If write access to a directory is needed, please make sure that it doesn't conta
 - `coinbase`: The value of `block.coinbase` in tests. Defaults to `0x0000000000000000000000000000000000000000`.
 - `blockTimestamp`: The value of `block.timestamp` in tests. Defaults to 1.
 - `blockGasLimit`: The `block.gaslimit` value during EVM execution. Set it to false to disable the block gas limit. Defaults to none.
-- `forkConfig`: The global fork configuration options object. If this is set, all tests are ran in fork mode. Defaults to none.
+- `forkConfig`: The global fork configuration options object. If this is set, all tests are run in fork mode. Defaults to none.
   - `url`: If set, all tests are run in fork mode using this url or remote name. Defaults to none.
   - `forkBlockNumber`: Pins the block number for the global state fork.
   - `rpcEndpoints`: Map of RPC endpoints from chain name to RPC urls for fork cheat codes, e.g. `{ "optimism": "https://optimism.alchemyapi.io/v2/..." }`
@@ -249,7 +249,7 @@ If write access to a directory is needed, please make sure that it doesn't conta
 - `fuzz`: Optional fuzz testing configuration object.
   - `failurePersistDir`: Optional path where fuzz failures are recorded and replayed if set.
   - `failurePersistFile`: Name of the file to record fuzz failures, defaults to `failures`.
-  - `runs`: The amount of fuzz runs to perform for each fuzz test case. Higher values gives more confidence in results at the cost of testing speed. Defaults to 256.
+  - `runs`: The amount of fuzz runs to perform for each fuzz test case. Higher values give more confidence in results at the cost of testing speed. Defaults to 256.
   - `maxTestRejects`: The maximum number of combined inputs that may be rejected before the test as a whole aborts. "Global" filters apply to the whole test case. If the test case is rejected, the whole thing is regenerated. Defaults to 65536.
   - `seed`: Hexadecimal string. Optional seed for the fuzzing RNG algorithm. Defaults to None.
   - `dictionaryWeight`: Integer between 0 and 100. The weight of the dictionary. A higher dictionary weight will bias the fuzz inputs towards "interesting" values, e.g. boundary values like type(uint256).max or contract addresses from your environment. Defaults to 40.
@@ -264,7 +264,7 @@ If write access to a directory is needed, please make sure that it doesn't conta
   - `dictionaryWeight`: Integer between 0 and 100. The weight of the dictionary. A higher dictionary weight will bias the fuzz inputs towards "interesting" values, e.g. boundary values like type(uint256).max or contract addresses from your environment. Defaults to 40.
   - `includeStorage`: The flag indicating whether to include values from storage. Defaults to true.
   - `includePushBytes`: The flag indicating whether to include push bytes values. Defaults to true.
-  - `shrinkRunLimit`: The maximum number of attempts to shrink a failed the sequence. Shrink process is disabled if set to 0. Defaults to 5000.
+  - `shrinkRunLimit`: The maximum number of attempts to shrink a failed sequence. The shrink process is disabled if set to 0. Defaults to 5000.
 
 ## Toolbox options
 

--- a/src/content/docs/reference/configuration.md
+++ b/src/content/docs/reference/configuration.md
@@ -246,7 +246,6 @@ If write access to a directory is needed, please make sure that it doesn't conta
   - `forkBlockNumber`: Pins the block number for the global state fork.
   - `rpcEndpoints`: Map of RPC endpoints from chain name to RPC urls for fork cheat codes, e.g. `{ "optimism": "https://optimism.alchemyapi.io/v2/..." }`
 - `rpcStorageCaching`: What RPC endpoints are cached. Defaults to all.
-- `timeout`: The maximum time in milliseconds to wait for all the test suites to finish. Optional, defaults to none.
 - `fuzz`: Optional fuzz testing configuration object.
   - `failurePersistDir`: Optional path where fuzz failures are recorded and replayed if set.
   - `failurePersistFile`: Name of the file to record fuzz failures, defaults to `failures`.


### PR DESCRIPTION
This PR adds documentation for all Solidity test config options exposed by Hardhat to the user and improves the documentation of `fsPermissions`.

I compiled the documentation by looking at what config options [Hardhat exposes](https://github.com/NomicFoundation/hardhat/blob/b0aafa6d4e1561c3027826e4c9ab1088b38806c8/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts#L14) to the user and then copying the documentation [from EDR](https://github.com/NomicFoundation/edr/blob/ce3c978db8fa678e9231860e5311dfd313a8a7b4/crates/edr_napi/index.d.ts#L523) for each property.

Please note that https://github.com/NomicFoundation/hardhat/pull/7216 should get merged first as `allowInternalExpectRevert` ~and `timeout` are~ is not exposed yet in the latest released version of Hardhat.