### PR TITLE
chore: remove beta status mention of `hardhat-deploy`

### DIFF
--- a/src/content/docs/learn-more/beta-status.md
+++ b/src/content/docs/learn-more/beta-status.md
@@ -20,8 +20,6 @@ There are some features that are still in development, and should be released so
 
 - Gas snapshots: The ability to take gas snapshots and compare them is still under development.
 
-- `hardhat-deploy` support: We are working on porting over the [`hardhat-deploy`](https://www.npmjs.com/package/hardhat-deploy) plugin to Hardhat 3.
-
 ## Migration blockers
 
 If your migration is blocked by a missing feature or plugin, please let us know [in this issue](https://github.com/NomicFoundation/hardhat/issues/7207).


### PR DESCRIPTION
Hardhat deploy is available as a plugin.