### PR TITLE
fixed issue with hardhat init example code

### DIFF
--- a/src/content/docs/getting-started/index.md
+++ b/src/content/docs/getting-started/index.md
@@ -32,7 +32,7 @@ Once that's done, initialize your Hardhat project by running:
 :::tab{value=npm}
 
 ```bash
-npx hardhat --init
+npx hardhat init
 ```
 
 :::


### PR DESCRIPTION
the docs are telling you to use `npx hardhat --init` and that will spit out `Error HH304: Unrecognised command line argument --init.`

`npx hardhat init` is what actually works