### PR TITLE
Update Hardhat explorerUrl config

### DIFF
--- a/src/content/ignition/docs/config/index.md
+++ b/src/content/ignition/docs/config/index.md
@@ -25,37 +25,37 @@ These are the different options you can add to your Hardhat config file.
 
 The time in milliseconds that Hardhat Ignition will wait between checks that a new block has been minted.
 
-Default value: 1000 milliseconds (1 second).
+Default value: `1_000` (1 second)
 
 ### `timeBeforeBumpingFees`
 
 The time in milliseconds to wait before bumping the fee for an unconfirmed transaction.
 
-Default value: 180,000 milliseconds (3 minutes).
+Default value: `180_000` (3 minutes)
 
 ### `maxFeeBumps`
 
 The number of times an unconfirmed transaction will have its fee bumped before Hardhat Ignition considers it timed out.
 
-Default value: 4.
+Default value: `4`
 
 ### `requiredConfirmations`
 
 The number of confirmations Hardhat Ignition waits before considering a transaction as complete. This provides control over block re-org risk.
 
-Default value: 5
+Default value: `5`
 
 ### `disableFeeBumping`
 
 If set to `true`, Hardhat Ignition will not bump the fee for unconfirmed transactions. Overrides the `disableFeeBumping` option in the network configuration.
 
-Default value: false
+Default value: `false`
 
 ### `explorerUrl`
 
 The default block explorer to use.
 
-Default value: undefined
+Default value: `undefined`
 
 ## Network configuration options
 
@@ -87,25 +87,25 @@ These are the different options you can add to the per-network `ignition` config
 
 If set, places a limit on the maximum fee per gas that Hardhat Ignition will allow when sending transactions. If Hardhat Ignition's calculated max fee per gas is higher than the limit, the deployment will be stopped with an error. This is useful for preventing accidental high fees during busy periods.
 
-Default value: undefined
+Default value: `undefined`
 
 ### `maxFeePerGas`
 
 The maximum fee per gas, in wei, that Hardhat Ignition will use when sending transactions. If not set then Hardhat Ignition will try to use the base fee from the latest block instead.
 
-Default value: undefined
+Default value: `undefined`
 
 ### `maxPriorityFeePerGas`
 
 The maximum priority fee per gas, in wei, that Hardhat Ignition will use for gas fee calculations when sending transactions. If not set then Hardhat Ignition will try to use `eth_maxPriorityFeePerGas` if available, or default to 1 gwei.
 
-Default value: undefined
+Default value: `undefined`
 
 ### `gasPrice`
 
 The gas price, in wei, that Hardhat Ignition will use for gas fee calculations when sending transactions. **This field only applies to deployments on the Polygon network. It will not be used on other networks even if set.**
 
-Default value: undefined
+Default value: `undefined`
 
 ### `disableFeeBumping`
 
@@ -117,4 +117,4 @@ Default value: false
 
 The default block explorer to use.
 
-Default value: undefined
+Default value: `undefined`

--- a/src/content/ignition/docs/config/index.md
+++ b/src/content/ignition/docs/config/index.md
@@ -51,6 +51,12 @@ If set to `true`, Hardhat Ignition will not bump the fee for unconfirmed transac
 
 Default value: false
 
+### `explorerUrl`
+
+The default block explorer to use.
+
+Default value: undefined
+
 ## Network configuration options
 
 You can use the `ignition` field under specific network configurations to customize deployments on a per-network basis:
@@ -67,6 +73,7 @@ export default {
         maxPriorityFeePerGas: 2_000_000_000n, // 2 gwei
         gasPrice: 50_000_000_000n, // 50 gwei
         disableFeeBumping: false,
+        explorerUrl: "https://sepolia.etherscan.io"
       },
       // ...
     },
@@ -105,3 +112,9 @@ Default value: undefined
 If set to `true`, Hardhat Ignition will not bump the fee for unconfirmed transactions on this network. Is overridden by the top-level `disableFeeBumping` option.
 
 Default value: false
+
+### `explorerUrl`
+
+The default block explorer to use.
+
+Default value: undefined

--- a/src/content/ignition/docs/config/index.md
+++ b/src/content/ignition/docs/config/index.md
@@ -73,7 +73,7 @@ export default {
         maxPriorityFeePerGas: 2_000_000_000n, // 2 gwei
         gasPrice: 50_000_000_000n, // 50 gwei
         disableFeeBumping: false,
-        explorerUrl: "https://sepolia.etherscan.io"
+        explorerUrl: "https://sepolia.etherscan.io",
       },
       // ...
     },


### PR DESCRIPTION
**1. Update Hardhat explorerUrl config for Configuration and Network Configuration options**

### `explorerUrl`

The default block explorer to use.

Default value: undefined

**2. Update relevant example for Sepolia network**

```
export default {
  networks: {
    sepolia: {
      // ...
      ignition: {
        maxFeePerGasLimit: 50_000_000_000n, // 50 gwei
        maxFeePerGas: 20_000_000_000n, // 20 gwei
        maxPriorityFeePerGas: 2_000_000_000n, // 2 gwei
        gasPrice: 50_000_000_000n, // 50 gwei
        disableFeeBumping: false,
        explorerUrl: "https://sepolia.etherscan.io"
      },
      // ...
    },
  },
};
```