### PR TITLE
Change the npm tag used in the website scripts to 'latest'

### DIFF
--- a/scripts/download-plugin-readmes-and-downloads-count.ts
+++ b/scripts/download-plugin-readmes-and-downloads-count.ts
@@ -6,7 +6,7 @@ import {
 } from "../src/content/plugins/plugins";
 import type { IPlugin } from "../src/model/types";
 
-const NPM_TAG = `next`;
+const NPM_TAG = `latest`;
 
 const PLUGINS_FOLDER = path.join(__dirname, "../src/content/plugins");
 

--- a/scripts/prepare-error-list.ts
+++ b/scripts/prepare-error-list.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 
-const HARDHAT_ERRORS_TAG = "next";
+const HARDHAT_ERRORS_TAG = "latest";
 const ERROR_DESCRIPTORS_URL = `https://unpkg.com/@nomicfoundation/hardhat-errors@${HARDHAT_ERRORS_TAG}/dist/src/descriptors.js`;
 const ERROR_DESCRIPTORS_FILE = path.join(
   __dirname,

--- a/scripts/prepare-markdown-replacement-values.ts
+++ b/scripts/prepare-markdown-replacement-values.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-const HARDHAT3_NPM_TAG = "next";
+const HARDHAT3_NPM_TAG = "latest";
 
 const REAPLACEMENT_VALUES_JSON = path.join(
   __dirname,


### PR DESCRIPTION
We were still building the website using `next` to download info about some packages.