### PR TITLE
Replace `esnext` with `node16`

### DIFF
--- a/src/content/migrate-from-hardhat2/index.md
+++ b/src/content/migrate-from-hardhat2/index.md
@@ -149,7 +149,7 @@ Before making any changes, prepare your project so that installing and running H
 
 6. **(Optional) Adapt your `tsconfig.json`**
 
-   If you have a `tsconfig.json` file, make sure that `compilerOptions.module` is set to an ESM-compatible value like `"esnext"`.
+   If you have a `tsconfig.json` file, make sure that `compilerOptions.module` is set to an ESM-compatible value like `"node16"`.
 
 ## Setting up Hardhat 3
 


### PR DESCRIPTION
`esnext` doesn't actually work. I'm replacing it with `node16` because that's what the sample project uses.