### PR TITLE
Fix prepare-error-list script

### DIFF
--- a/scripts/prepare-error-list.ts
+++ b/scripts/prepare-error-list.ts
@@ -86,13 +86,18 @@ using Hardhat and an explanation of each of them.`;
     for (const [rangeName, range] of Object.entries(
       packageCategories.CATEGORIES
     )) {
+      const errorDescriptors = ERRORS[packageName][rangeName];
+      if (errorDescriptors === undefined) {
+        continue;
+      }
+
       content += `
 
 ### ${range.websiteSubTitle}
 `;
 
       for (const errorDescriptor of Object.values<ErrorDescriptor>(
-        ERRORS[packageName][rangeName]
+        errorDescriptors
       )) {
         const errorCode = `hhe${errorDescriptor.number}`;
         const title = `${errorCode.toUpperCase()}: ${


### PR DESCRIPTION
The `prepare-error-list` script fails if a category is defined but no error is added to that category. @ChristopherDedominici explained it in [this comment](https://github.com/NomicFoundation/hardhat-website/pull/105#issuecomment-3431561468).

Chris removed that category in [this PR](https://github.com/NomicFoundation/hardhat/pull/7610), but this won't have an effect until the `hardhat-errors` package is published (we didn't add a changeset because I wrongly suggested it was unnecessary).

This PR just fixes the script to ignore these scenarios.