### PR TITLE
docs: remove delivered features from WIP list

### DIFF
--- a/src/content/docs/docs/hardhat3/beta-status.mdx
+++ b/src/content/docs/docs/hardhat3/beta-status.mdx
@@ -19,13 +19,7 @@ Take a look at the [migration guide](/docs/migrate-from-hardhat2) to see how to 
 
 There are some features that are still in development, and should be released soon:
 
-- Ledger support: We are working on porting over the `@nomicfoundation/hardhat-ledger` plugin, and should be available soon.
-
-- Gas reporting: Hardhat 3 will have a built-in alternative for the [`hardhat-gas-reporter`](https://www.npmjs.com/package/hardhat-gas-reporter) plugin, which will work with Solidity and Typescript tests.
-
 - Gas snapshots: The ability to take gas snapshots and compare them is still under development.
-
-- `hardhat-deploy` support: We are working on porting over the [`hardhat-deploy`](https://www.npmjs.com/package/hardhat-deploy) plugin to Hardhat 3.
 
 ## Migration blockers
 


### PR DESCRIPTION
We now have a version of `hardhat-deploy`, gas statistics and `hardhat-ledger`, so this PR removes them from the WIP feature list.