### PR TITLE
Add hardhat node guide

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -124,7 +124,7 @@ export default defineConfig({
                       link: "http://hardhat.org/docs/explanations/edr-simulated-networks#forking-mode",
                     },
                     // { slug: "docs/guides/forking" },
-                    // { slug: "docs/guides/hardhat-node" },
+                    { slug: "docs/guides/hardhat-node" },
                     // { slug: "docs/guides/hardhat-console" },
                     // { slug: "docs/guides/command-line-completion" },
                     { slug: "docs/guides/getting-help" },

--- a/src/content/docs/docs/guides/hardhat-node.mdx
+++ b/src/content/docs/docs/guides/hardhat-node.mdx
@@ -1,0 +1,88 @@
+---
+title: Running a local development node
+description: How to run and configure a local Hardhat development node for testing and development
+---
+
+import Run from "@hh/Run.astro";
+
+The Hardhat `node` task starts a local development node that runs until you stop it, exposing an HTTP-based JSON-RPC server for your scripts and applications to connect to.
+
+## Using the node task
+
+Suppose you have a script that sends 1 ETH from the first local account to the zero address and then prints its balance:
+
+```ts
+// my-script.ts
+import { network } from "hardhat";
+
+const { viem } = await network.connect();
+const publicClient = await viem.getPublicClient();
+const [wallet] = await viem.getWalletClients();
+
+await wallet.sendTransaction({
+  to: "0x0000000000000000000000000000000000000000",
+  value: 10n ** 18n,
+});
+
+const zeroAddressBalance = await publicClient.getBalance({
+  address: "0x0000000000000000000000000000000000000000",
+});
+
+console.log(`Balance of zero address: ${zeroAddressBalance}`);
+```
+
+If you run this script multiple times, the output won't change:
+
+<Run command="hardhat run my-script.ts" />
+
+To have a locally simulated network that persists for longer than the duration of a single task, start a node in one terminal:
+
+<Run command="hardhat node" />
+
+Then, in another terminal, run your script using the `--network localhost` option, which connects to the running node:
+
+<Run command="hardhat run my-script.ts --network localhost" />
+
+Now, if you run the script again while the node is running, you'll see the output change each time, as the state is preserved between runs.
+
+## Running a development node programmatically
+
+In addition to using the `hardhat node` task, you can start a development node programmatically using the Network Manager's `createServer` method. This method creates a local simulated network and exposes it through an HTTP-based JSON-RPC server, just like `hardhat node`.
+
+Here's a complete example that creates a server, runs it for 60 seconds, and then closes it:
+
+```ts
+// scripts/server.ts
+import { network } from "hardhat";
+
+// Create a JsonRpcServer wrapping a blockchain simulation based on the
+// "default" Network Config, with `loggingEnabled` setting overridden to `true`
+const server = await network.createServer(
+  {
+    network: "default",
+    override: { loggingEnabled: true },
+  },
+  // hostname and port are optional parameters
+  // "127.0.0.1",
+  // 8545,
+);
+
+const { address, port } = await server.listen();
+console.log(`JSON-RPC running in: http://${address}:${port}`);
+
+// Example of closing the server from another async context
+console.log("Closing the server in 60 seconds");
+setTimeout(async () => {
+  await server.close();
+}, 60_000);
+
+// Wait for the server to close before printing a message
+await server.afterClosed();
+console.log("Server closed");
+```
+
+Run this script with:
+
+<Run command="hardhat run scripts/server.ts" />
+
+While the server is running, you can connect to it through HTTP, for example using `--network localhost`, or any client with its address and port.

--- a/src/content/docs/docs/guides/hardhat-node.todo
+++ b/src/content/docs/docs/guides/hardhat-node.todo
@@ -1,6 +1,0 @@
----
-title: Running a local development node
-description: How to run and configure a local Hardhat development node for testing and development
----
-
-TODO

--- a/src/content/docs/docs/reference/network-manager.mdx
+++ b/src/content/docs/docs/reference/network-manager.mdx
@@ -200,47 +200,24 @@ If you provide a Chain Type both as an option and as part of your Network Config
 
 ### The `network.createServer()` method
 
-If you need to create a network simulation and expose its JSON-RPC through HTTP, like `hardhat node` does, you can use the `network.createServer()` method. It takes the same arguments as `network.connect()`, plus two additional optional arguments:
+The `network.createServer()` method creates a local blockchain simulation and exposes it through an HTTP-based JSON-RPC server, similar to what `hardhat node` does.
 
-- `hostname`: The hostname of the network interface the server should use to listen for new connections. It defaults to `"127.0.0.1"` if not provided, and to `"0.0.0.0"` if running on a Docker container.
-- `port`: The port to use in the HTTP server. If not provided, your OS will assign an unused random port.
+#### Parameters
 
-Calling `await network.createServer()` returns a `JsonRpcServer` object, which has these methods:
+This method takes the same arguments as `network.connect()`, plus two additional optional parameters:
 
-- `listen()`: To start the server and return the `hostname` and `port` being used.
-- `close()`: To stop the server.
-- `afterClosed()`: Which you can use to await for the server to be closed. This is helpful if the `close()` method is called from a different async context.
+- `hostname`: The hostname of the network interface the server should use to listen for new connections. Defaults to `"127.0.0.1"`, or `"0.0.0.0"` if running in a Docker container.
+- `port`: The port to use for the HTTP server. If not provided, an unused random port will be assigned by the OS.
 
-To see a complete example, create a `scripts/server.ts` file with this content:
+#### Return value
 
-```ts
-// scripts/server.ts
-import { network } from "hardhat";
+Calling `await network.createServer()` returns a `JsonRpcServer` object, which provides the following methods:
 
-// Create a JsonRpcServer wrapping a blockchain simulation based on the
-// "default" Network Config, with `loggingEnabled` setting overridden to `true`
-const server = await network.createServer({
-  network: "default",
-  override: { loggingEnabled: true },
-});
+- `listen()`: Starts the server and returns the `hostname` and `port` being used.
+- `close()`: Stops the server.
+- `afterClosed()`: Returns a promise that resolves when the server has fully closed. Useful if `close()` is called from another async context.
 
-const { address, port } = await server.listen();
-console.log(`JSON-RPC running in: http://${address}:${port}`);
-
-// Example of closing the server from another async context
-console.log("Closing the server in 60 seconds");
-setTimeout(async () => {
-  await server.close();
-}, 60_000);
-
-// Wait for the server to close before printing a message
-await server.afterClosed();
-console.log("Server closed");
-```
-
-And you can run it with:
-
-<Run command="hardhat run scripts/server.ts" />
+To learn more about how to use this method, see the [Running a local development node guide](/docs/guides/hardhat-node#running-a-development-node-programmatically).
 
 ## The `NetworkConnection<ChainTypeT>` object
 


### PR DESCRIPTION
I added a guide for the `node` task and also moved most of the `createServer` content in the network manager reference here, since I think it's very hands-on and fits better as a section of this guide.