### PR TITLE
Remove backticks in title

### DIFF
--- a/src/content/docs/docs/reference/console-log.mdx
+++ b/src/content/docs/docs/reference/console-log.mdx
@@ -1,5 +1,5 @@
 ---
-title: Solidity `console.log()` reference
+title: Solidity console.log() reference
 description: Reference documentation of Hardhat's Solidity console.log() functionality
 sidebar:
   label: Solidity console.log


### PR DESCRIPTION
Backticks in titles are not rendered, which makes the title looks buggy:

<img width="723" height="179" alt="image" src="https://github.com/user-attachments/assets/088f4e5c-b084-4050-9771-7f1beef940a4" />

This PR just removes the backticks:

<img width="723" height="179" alt="image" src="https://github.com/user-attachments/assets/500eca4b-0531-4a6f-a8b9-1d350e7e3763" />
