### PR TITLE
fix: display warning as admonition

### DIFF
--- a/src/content/docs/docs/reference/configuration.mdx
+++ b/src/content/docs/docs/reference/configuration.mdx
@@ -233,7 +233,7 @@ export default defineConfig({
 
 The following options are available for configuring Solidity tests:
 
-:::warning
+:::caution
 
 Giving write access to configuration files, source files or executables in a project is considered dangerous, because it can be used by malicious Solidity dependencies to escape the EVM sandbox.
 It is therefore recommended to give write access to specific safe files only.


### PR DESCRIPTION
The previous warning callout isn't displayed on the website. The fix is to replace `:::warning` with `:::caution`.

https://hardhat-website-git-agostbiro-patch-1-nomic-foundation.vercel.app/docs/reference/configuration#solidity-tests-configuration