### PR TITLE
Redistributable requirement for Windows

### DIFF
--- a/src/content/docs/docs/tutorial/setup.mdx
+++ b/src/content/docs/docs/tutorial/setup.mdx
@@ -16,7 +16,6 @@ Before you start, make sure you have [Node.js](https://nodejs.org/) 22+ and a pa
 If you don't have Node.js installed, or you have an older version, you can learn how to install or update it using `nvm` or `volta` in [this guide](https://nodejs.org/en/download).
 
 On Windows, you will also need the C++ runtime libraries. You can get them by installing the [C++ redistributable package](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist).
-The recommended version is [v14](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#visual-c-redistributable-v14) available [here](https://aka.ms/vc14/vc_redist.x64.exe) (for AMD64).
 
 ## Creating your project
 


### PR DESCRIPTION
Adding a note that C++ redist is needed for Windows to mitigate issues similar to https://github.com/NomicFoundation/hardhat/issues/7831