### PR TITLE
Add `hardhat-airsign` to community plugins

### DIFF
--- a/src/content/hardhat-runner/plugins/plugins.ts
+++ b/src/content/hardhat-runner/plugins/plugins.ts
@@ -1035,6 +1035,15 @@ const communityPlugins: IPlugin[] = [
       "script",
     ],
   },
+  {
+    name: "hardhat-airsign",
+    author: "Harshit Sharmaa",
+    authorUrl: "https://github.com/harshitbwc",
+    description: "Hardhat plugin to deploy smart contracts without private keys. Sign transactions from any browser or remotely from your wallet, run tasks & scripts from a browser UI",
+    tags: [
+      "hardhat", "hardhat-plugin", "smart-contracts", "ethereum", "web3", "remote-signing"
+      ]
+  }
 ];
 
 const officialPlugins: IPlugin[] = [


### PR DESCRIPTION
With `hardhat-airsign` you can deploy smart contracts from your dev machine. Sign transactions from anywhere. no private keys in .env files ever. Run Hardhat tasks and scripts directly from the browser.