### PR TITLE
update block gas limit

### DIFF
--- a/src/content/docs/docs/reference/configuration.mdx
+++ b/src/content/docs/docs/reference/configuration.mdx
@@ -156,7 +156,7 @@ The following options are specific to simulated networks:
 - `accounts`: This field controls which accounts Hardhat uses. It can use a list of local accounts (by setting it to an array of `{privateKey, balance}` objects) or an [HD Wallet](#hd-wallet-config). Default value: an HD Wallet with 20 unlocked accounts and a balance of 10,000 ETH each.
 - `allowBlocksWithSameTimestamp`: A boolean to allow mining blocks that have the same timestamp. This is not allowed by default because Ethereum's consensus rules specify that each block should have a different timestamp. Default value: `false`.
 - `allowUnlimitedContractSize`: An optional boolean that disables the contract size limit imposed by [EIP-170](https://eips.ethereum.org/EIPS/eip-170). Default value: `false`.
-- `blockGasLimit`: The block gas limit to use in Hardhat Network's blockchain. Default value: `30_000_000`.
+- `blockGasLimit`: The block gas limit to use in Hardhat Network's blockchain. Default value: `60_000_000`.
 - `coinbase`: The address used as coinbase in new blocks. Default value: `"0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e"`.
 - `forking`: An object that describes the forking configuration and can have the following fields:
   - `url`: a URL that points to a JSON-RPC node with state that you want to fork off. There's no default value for this field. It must be provided for the fork to work.


### PR DESCRIPTION
In Osaka, the max gas per block was raised from 30m to 60m; change our docs to reflect our new default.

See https://github.com/NomicFoundation/hardhat/issues/7759 for reference to the original change.

Evidence: https://github.com/NomicFoundation/hardhat/blob/a9177b3f0435ace0364c94ceaa41bccb34c0ca94/packages/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts#L88