### PR TITLE
Improve LLMs visibility

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Allow: /
 
 Sitemap: https://hardhat.org/sitemap-index.xml

--- a/src/components/starlight-overrides/Head.astro
+++ b/src/components/starlight-overrides/Head.astro
@@ -1,9 +1,17 @@
 ---
 import Default from "@astrojs/starlight/components/Head.astro";
 import { globalConfig } from "../../config";
+
+const markdownHref = `${Astro.url.pathname}.md`;
 ---
 
 <Default><slot /></Default>
+<link
+  rel="alternate"
+  type="text/markdown"
+  title="Markdown version"
+  href={markdownHref}
+/>
 <Fragment
   set:html={`
 <!--

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,6 +18,12 @@ import WhyHardhat from "../components/landing/WhyHardhat/WhyHardhat.astro";
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
+    <link
+      rel="alternate"
+      type="text/markdown"
+      title="Markdown version"
+      href="/index.md"
+    />
 
     <Fragment
       set:html={`

--- a/vercel.json
+++ b/vercel.json
@@ -19,7 +19,7 @@
       ]
     },
     {
-      "source": "/:path((?!.*\\.md$)(?!.*\\.html$)(?!.*\\.txt$).*)",
+      "source": "/:path((?!.*\\.md$)(?!.*\\.html$)(?!.*\\.txt$).+)",
       "headers": [
         { "key": "Vary", "value": "Accept" },
         {

--- a/vercel.json
+++ b/vercel.json
@@ -10,11 +10,23 @@
     },
     {
       "source": "/",
-      "headers": [{ "key": "Vary", "value": "Accept" }]
+      "headers": [
+        { "key": "Vary", "value": "Accept" },
+        {
+          "key": "Link",
+          "value": "</index.md>; rel=\"alternate\"; type=\"text/markdown\""
+        }
+      ]
     },
     {
       "source": "/:path((?!.*\\.md$)(?!.*\\.html$)(?!.*\\.txt$).*)",
-      "headers": [{ "key": "Vary", "value": "Accept" }]
+      "headers": [
+        { "key": "Vary", "value": "Accept" },
+        {
+          "key": "Link",
+          "value": "</:path.md>; rel=\"alternate\"; type=\"text/markdown\""
+        }
+      ]
     }
   ],
   "trailingSlash": false,


### PR DESCRIPTION
This PR adds two changes that _allegedly_ help LLMs.

The first one is adding a `Content-Signal` directive to robots.txt that basically says "all AI overlords welcome". This is being [pushed by Cloudflare](https://contentsignals.org/) and I'm not sure it really matters if you already have the maximally permissive `User-agent: *` and `Allow: /`. But it's a one-line change, doesn't hurt, and improves the score in https://isitagentready.com/.

The second change has more chances of being useful. It adds Link headers and tags which point to the markdown version of the page. The isitagentready.com tool only checks for Link headers, but [this pretty good article](https://evilmartians.com/chronicles/how-to-make-your-website-visible-to-llms) also recommends adding Link tags.

I've checked everything locally except the Link headers. Since those are part of Vercel's config, I'll have to wait for the deploy preview to double-check that they work as expected.