### PR TITLE
Support EIP-712 cheatcodes in Solidity Test

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@astrojs/vercel": "^8.2.8",
     "@expressive-code/plugin-collapsible-sections": "^0.41.3",
     "@expressive-code/plugin-line-numbers": "^0.41.3",
-    "@nomicfoundation/hardhat-errors": "^3.0.10",
+    "@nomicfoundation/hardhat-errors": "^3.0.12",
     "@types/tar-stream": "^3.1.4",
     "astro": "^5.6.1",
     "cspell": "^9.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^0.41.3
         version: 0.41.3
       '@nomicfoundation/hardhat-errors':
-        specifier: ^3.0.10
-        version: 3.0.10
+        specifier: ^3.0.12
+        version: 3.0.12
       '@types/tar-stream':
         specifier: ^3.1.4
         version: 3.1.4
@@ -767,11 +767,11 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/hardhat-errors@3.0.10':
-    resolution: {integrity: sha512-jfQ75/t21674cIQPbQmzRSY8YdusvQhKMsT+IGEoXlJuAzw+ngWsD7y7nHT8UKQ+liHWgMA+Am2843KwP0KtiA==}
+  '@nomicfoundation/hardhat-errors@3.0.12':
+    resolution: {integrity: sha512-2viEq1D19FHWKpfB2vVeL0R6d+iZR2E5h0EhKQQMc1ukDUV2fel/7fRjlWuCOx2CFC+5mHL2saRcN8KlYsX8hg==}
 
-  '@nomicfoundation/hardhat-utils@4.0.2':
-    resolution: {integrity: sha512-6lK0+9ygB7wGDlu11DAmTuZxhnoGbyGZC2aRaKKehW0vDNTS9iT7GUimgVvlO3B23E/HwwRKOOLmSVPC4qmmQw==}
+  '@nomicfoundation/hardhat-utils@4.1.0':
+    resolution: {integrity: sha512-qze9X5P8LIB36rjS3cFhD7asG82pjZDmJAYfCQBSDhMYJM1HDZrYKgKfJLEE36TmrhjgQ/hlNO0DikDq0e2VYg==}
 
   '@nomicfoundation/slang@1.2.0':
     resolution: {integrity: sha512-+04Z1RHbbz0ldDbHKQFOzveCdI9Rd3TZZu7fno5hHy3OsqTo9UK5Jgqo68wMvRovCO99POv6oCEyO7+urGeN8Q==}
@@ -3783,24 +3783,19 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nomicfoundation/hardhat-errors@3.0.10':
+  '@nomicfoundation/hardhat-errors@3.0.12':
     dependencies:
-      '@nomicfoundation/hardhat-utils': 4.0.2
-    transitivePeerDependencies:
-      - supports-color
+      '@nomicfoundation/hardhat-utils': 4.1.0
 
-  '@nomicfoundation/hardhat-utils@4.0.2':
+  '@nomicfoundation/hardhat-utils@4.1.0':
     dependencies:
       '@streamparser/json-node': 0.0.22
-      debug: 4.4.3
       env-paths: 2.2.1
       ethereum-cryptography: 2.2.1
       fast-equals: 5.4.0
       json-stream-stringify: 3.1.6
       rfdc: 1.4.1
       undici: 6.22.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@nomicfoundation/slang@1.2.0':
     dependencies:

--- a/src/content/docs/docs/guides/testing/eip712-types.mdx
+++ b/src/content/docs/docs/guides/testing/eip712-types.mdx
@@ -98,4 +98,4 @@ contract Eip712Test is Test {
 
 ## Duplicate struct names
 
-Each struct name must map to exactly one definition across the collected set. If two different structs share a name, the test run fails with error `HHE817`. To fix this, rename one of the structs or narrow your `include`/`exclude` globs. Identical definitions across multiple build infos are deduplicated silently.
+Each struct name must map to exactly one definition across the collected set. If two different structs share a name, the test run fails with error `HHE818`. To fix this, rename one of the structs or narrow your `include`/`exclude` globs. Identical definitions across multiple build infos are deduplicated silently.

--- a/src/content/docs/docs/guides/testing/eip712-types.mdx
+++ b/src/content/docs/docs/guides/testing/eip712-types.mdx
@@ -73,7 +73,7 @@ interface IEip712Cheats {
 contract Eip712Test is Test {
   IEip712Cheats cheats = IEip712Cheats(address(vm));
 
-  function testMailTypeHash() public view {
+  function testMailTypeHash() public {
     bytes32 expected = keccak256(
       bytes(
         "Mail(Person from,Person to,string contents)"
@@ -83,7 +83,7 @@ contract Eip712Test is Test {
     assertEq(cheats.eip712HashType("Mail"), expected);
   }
 
-  function testMailStructHash() public view {
+  function testMailStructHash() public {
     Mail memory m = Mail({
       from: Person({ wallet: address(0xA), name: "Alice" }),
       to: Person({ wallet: address(0xB), name: "Bob" }),

--- a/src/content/docs/docs/guides/testing/eip712-types.mdx
+++ b/src/content/docs/docs/guides/testing/eip712-types.mdx
@@ -7,6 +7,7 @@ sidebar:
 ---
 
 Hardhat provides three cheatcodes for EIP-712 hashing in Solidity tests:
+
 - [`eip712HashType`](/docs/reference/cheatcodes/utilities/eip712-hash-type)
 - [`eip712HashStruct`](/docs/reference/cheatcodes/utilities/eip712-hash-struct)
 - [`eip712HashTypedData`](/docs/reference/cheatcodes/utilities/eip712-hash-typed-data)
@@ -43,14 +44,14 @@ Given these struct definitions in `contracts/Eip712Types.sol`:
 
 ```solidity
 struct Person {
-    address wallet;
-    string name;
+  address wallet;
+  string name;
 }
 
 struct Mail {
-    Person from;
-    Person to;
-    string contents;
+  Person from;
+  Person to;
+  string contents;
 }
 ```
 
@@ -61,32 +62,37 @@ import "forge-std/Test.sol";
 import "../../contracts/Eip712Types.sol";
 
 interface IEip712Cheats {
-    function eip712HashType(string calldata) external pure returns (bytes32);
-    function eip712HashStruct(string calldata, bytes calldata) external pure returns (bytes32);
-    function eip712HashTypedData(string calldata) external pure returns (bytes32);
+  function eip712HashType(string calldata) external pure returns (bytes32);
+  function eip712HashStruct(
+    string calldata,
+    bytes calldata
+  ) external pure returns (bytes32);
+  function eip712HashTypedData(string calldata) external pure returns (bytes32);
 }
 
 contract Eip712Test is Test {
-    IEip712Cheats cheats = IEip712Cheats(address(vm));
+  IEip712Cheats cheats = IEip712Cheats(address(vm));
 
-    function testMailTypeHash() public view {
-        bytes32 expected = keccak256(bytes(
-            "Mail(Person from,Person to,string contents)"
-            "Person(address wallet,string name)"
-        ));
-        assertEq(cheats.eip712HashType("Mail"), expected);
-    }
+  function testMailTypeHash() public view {
+    bytes32 expected = keccak256(
+      bytes(
+        "Mail(Person from,Person to,string contents)"
+        "Person(address wallet,string name)"
+      )
+    );
+    assertEq(cheats.eip712HashType("Mail"), expected);
+  }
 
-    function testMailStructHash() public view {
-        Mail memory m = Mail({
-            from: Person({ wallet: address(0xA), name: "Alice" }),
-            to:   Person({ wallet: address(0xB), name: "Bob"   }),
-            contents: "hello"
-        });
+  function testMailStructHash() public view {
+    Mail memory m = Mail({
+      from: Person({ wallet: address(0xA), name: "Alice" }),
+      to: Person({ wallet: address(0xB), name: "Bob" }),
+      contents: "hello"
+    });
 
-        bytes32 hash = cheats.eip712HashStruct("Mail", abi.encode(m));
-        // hash now equals the standard EIP-712 struct hash for `m`.
-    }
+    bytes32 hash = cheats.eip712HashStruct("Mail", abi.encode(m));
+    // hash now equals the standard EIP-712 struct hash for `m`.
+  }
 }
 ```
 

--- a/src/content/docs/docs/guides/testing/eip712-types.mdx
+++ b/src/content/docs/docs/guides/testing/eip712-types.mdx
@@ -34,7 +34,7 @@ export default defineConfig({
 });
 ```
 
-> **Note:** To include structs from npm packages, match against the input source name used by solc (e.g., `"npm/@uniswap/permit2@*/src/interfaces/ISignatureTransfer.sol"`). For the full reference, see [Solidity tests configuration](/docs/reference/configuration#solidity-tests-configuration).
+> **Note:** To include structs from npm packages, match against the input source name used by solc (e.g. `"npm/@uniswap/permit2@*/src/interfaces/ISignatureTransfer.sol"`). For the full reference, see [Solidity tests configuration](/docs/reference/configuration#solidity-tests-configuration).
 
 ## Example
 

--- a/src/content/docs/docs/guides/testing/eip712-types.mdx
+++ b/src/content/docs/docs/guides/testing/eip712-types.mdx
@@ -1,0 +1,95 @@
+---
+title: EIP-712 type hashing in Solidity tests
+description: How to use EIP-712 type hashing cheatcodes in Solidity tests
+sidebar:
+  label: EIP-712 type hashing
+  order: 6
+---
+
+Hardhat provides three cheatcodes for EIP-712 hashing in Solidity tests:
+- [`eip712HashType`](/docs/reference/cheatcodes/utilities/eip712-hash-type)
+- [`eip712HashStruct`](/docs/reference/cheatcodes/utilities/eip712-hash-struct)
+- [`eip712HashTypedData`](/docs/reference/cheatcodes/utilities/eip712-hash-typed-data)
+
+The first two look up your project's struct definitions by name, avoiding hand-written canonical type strings. `eip712HashTypedData` computes a digest from a self-describing JSON payload and works without any configuration.
+
+## Configuration
+
+`eip712HashType` and `eip712HashStruct` need a registry of struct types to resolve names. Enable this by adding an `eip712Types` block to your `hardhat.config.ts`:
+
+```ts
+// hardhat.config.ts
+import { defineConfig } from "hardhat/config";
+
+export default defineConfig({
+  test: {
+    solidity: {
+      eip712Types: {
+        include: ["contracts/**", "test/contracts/**"],
+        // exclude: ["contracts/legacy/**"], // Optional
+      },
+    },
+  },
+});
+```
+
+> **Note:** To include structs from npm packages, match against the input source name used by solc (e.g., `"npm/@uniswap/permit2@*/src/interfaces/ISignatureTransfer.sol"`). For the full reference, see [Solidity tests configuration](/docs/reference/configuration#solidity-tests-configuration).
+
+## Example
+
+If your bundled `forge-std` doesn't expose these cheatcodes on its `vm` interface yet, declare a local interface and call them through the cheatcode address.
+
+Given these struct definitions in `contracts/Eip712Types.sol`:
+
+```solidity
+struct Person {
+    address wallet;
+    string name;
+}
+
+struct Mail {
+    Person from;
+    Person to;
+    string contents;
+}
+```
+
+You can hash types and structs in your tests:
+
+```solidity
+import "forge-std/Test.sol";
+import "../../contracts/Eip712Types.sol";
+
+interface IEip712Cheats {
+    function eip712HashType(string calldata) external pure returns (bytes32);
+    function eip712HashStruct(string calldata, bytes calldata) external pure returns (bytes32);
+    function eip712HashTypedData(string calldata) external pure returns (bytes32);
+}
+
+contract Eip712Test is Test {
+    IEip712Cheats cheats = IEip712Cheats(address(vm));
+
+    function testMailTypeHash() public view {
+        bytes32 expected = keccak256(bytes(
+            "Mail(Person from,Person to,string contents)"
+            "Person(address wallet,string name)"
+        ));
+        assertEq(cheats.eip712HashType("Mail"), expected);
+    }
+
+    function testMailStructHash() public view {
+        Mail memory m = Mail({
+            from: Person({ wallet: address(0xA), name: "Alice" }),
+            to:   Person({ wallet: address(0xB), name: "Bob"   }),
+            contents: "hello"
+        });
+
+        bytes32 hash = cheats.eip712HashStruct("Mail", abi.encode(m));
+        // hash now equals the standard EIP-712 struct hash for `m`.
+    }
+}
+```
+
+## Duplicate struct names
+
+Each struct name must map to exactly one definition across the collected set. If two different structs share a name, the test run fails with error `HHE817`. To fix this, rename one of the structs or narrow your `include`/`exclude` globs. Identical definitions across multiple build infos are deduplicated silently.

--- a/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-struct.mdx
+++ b/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-struct.mdx
@@ -14,7 +14,7 @@ function eip712HashStruct(
 
 ### Description
 
-Returns the EIP-712 **struct hash** for a registered struct name (e.g., `"Mail"`) and its `abi.encode`-d value.
+Returns the EIP-712 **struct hash** for a registered struct name (e.g. `"Mail"`) and its `abi.encode`-d value.
 
 This is **not** the final signable digest. To produce the digest that `ecrecover` expects, combine the struct hash with a domain separator: `keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash))`. Alternatively, use [`eip712HashTypedData`](/docs/reference/cheatcodes/utilities/eip712-hash-typed-data) to compute the complete digest in one call.
 

--- a/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-struct.mdx
+++ b/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-struct.mdx
@@ -1,0 +1,37 @@
+---
+title: eip712HashStruct
+description: eip712HashStruct cheatcode documentation
+---
+
+### Signature
+
+```solidity
+function eip712HashStruct(string calldata typeName, bytes calldata abiEncodedData)
+    external pure returns (bytes32);
+```
+
+### Description
+
+Returns the EIP-712 **struct hash** for a registered struct name (e.g., `"Mail"`) and its `abi.encode`-d value.
+
+This is **not** the final signable digest. To produce the digest that `ecrecover` expects, combine the struct hash with a domain separator: `keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash))`. Alternatively, use [`eip712HashTypedData`](/docs/reference/cheatcodes/utilities/eip712-hash-typed-data) to compute the complete digest in one call.
+
+> **Note:** Requires the `test.solidity.eip712Types` configuration. See the [EIP-712 type hashing guide](/docs/guides/testing/eip712-types) for setup and full signing examples.
+
+### Example
+
+```solidity
+Mail memory m = Mail({
+    from: Person({ wallet: address(0xA), name: "Alice" }),
+    to:   Person({ wallet: address(0xB), name: "Bob"   }),
+    contents: "hello"
+});
+
+bytes32 hash = cheats.eip712HashStruct("Mail", abi.encode(m));
+```
+
+### SEE ALSO
+
+- [eip712HashType](/docs/reference/cheatcodes/utilities/eip712-hash-type)
+- [eip712HashTypedData](/docs/reference/cheatcodes/utilities/eip712-hash-typed-data)
+- [EIP-712 type hashing guide](/docs/guides/testing/eip712-types)

--- a/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-struct.mdx
+++ b/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-struct.mdx
@@ -6,8 +6,10 @@ description: eip712HashStruct cheatcode documentation
 ### Signature
 
 ```solidity
-function eip712HashStruct(string calldata typeName, bytes calldata abiEncodedData)
-    external pure returns (bytes32);
+function eip712HashStruct(
+  string calldata typeName,
+  bytes calldata abiEncodedData
+) external pure returns (bytes32);
 ```
 
 ### Description

--- a/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-type.mdx
+++ b/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-type.mdx
@@ -15,7 +15,7 @@ function eip712HashType(
 
 Returns `keccak256(bytes(canonicalTypeString))` for the given EIP-712 type.
 
-The argument can be a registered struct name (e.g., `"Mail"`) or a full EIP-712 type definition string.
+The argument can be a registered struct name (e.g. `"Mail"`) or a full EIP-712 type definition string.
 
 > **Note:** Requires the `test.solidity.eip712Types` configuration. See the [EIP-712 type hashing guide](/docs/guides/testing/eip712-types) for setup.
 

--- a/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-type.mdx
+++ b/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-type.mdx
@@ -1,0 +1,39 @@
+---
+title: eip712HashType
+description: eip712HashType cheatcode documentation
+---
+
+### Signature
+
+```solidity
+function eip712HashType(string calldata typeNameOrDefinition)
+    external pure returns (bytes32);
+```
+
+### Description
+
+Returns `keccak256(bytes(canonicalTypeString))` for the given EIP-712 type.
+
+The argument can be a registered struct name (e.g., `"Mail"`) or a full EIP-712 type definition string.
+
+> **Note:** Requires the `test.solidity.eip712Types` configuration. See the [EIP-712 type hashing guide](/docs/guides/testing/eip712-types) for setup.
+
+### Examples
+
+```solidity
+// Look up by registered name
+bytes32 hash = cheats.eip712HashType("Mail");
+
+// Or pass a full type definition directly
+bytes32 hash2 = cheats.eip712HashType(
+    "Mail(Person from,Person to,string contents)Person(address wallet,string name)"
+);
+
+assertEq(hash, hash2);
+```
+
+### SEE ALSO
+
+- [eip712HashStruct](/docs/reference/cheatcodes/utilities/eip712-hash-struct)
+- [eip712HashTypedData](/docs/reference/cheatcodes/utilities/eip712-hash-typed-data)
+- [EIP-712 type hashing guide](/docs/guides/testing/eip712-types)

--- a/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-type.mdx
+++ b/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-type.mdx
@@ -6,8 +6,9 @@ description: eip712HashType cheatcode documentation
 ### Signature
 
 ```solidity
-function eip712HashType(string calldata typeNameOrDefinition)
-    external pure returns (bytes32);
+function eip712HashType(
+  string calldata typeNameOrDefinition
+) external pure returns (bytes32);
 ```
 
 ### Description

--- a/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-typed-data.mdx
+++ b/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-typed-data.mdx
@@ -1,0 +1,40 @@
+---
+title: eip712HashTypedData
+description: eip712HashTypedData cheatcode documentation
+---
+
+### Signature
+
+```solidity
+function eip712HashTypedData(string calldata jsonData)
+    external pure returns (bytes32);
+```
+
+### Description
+
+Returns the complete EIP-712 digest: `keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash))`.
+
+`jsonData` must be a self-describing EIP-712 JSON payload containing `domain`, `types`, `primaryType`, and `message` fields. This cheatcode is fully self-contained and **does not** require any `eip712Types` configuration in your `hardhat.config.ts`.
+
+### Example
+
+```solidity
+string memory json = '{'
+    '"domain":{"name":"Ether Mail","version":"1","chainId":1,"verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"},'
+    '"types":{'
+        '"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],'
+        '"Mail":[{"name":"from","type":"Person"},{"name":"to","type":"Person"},{"name":"contents","type":"string"}],'
+        '"Person":[{"name":"wallet","type":"address"},{"name":"name","type":"string"}]'
+    '},'
+    '"primaryType":"Mail",'
+    '"message":{"from":{"wallet":"0xA","name":"Alice"},"to":{"wallet":"0xB","name":"Bob"},"contents":"hello"}'
+'}';
+
+bytes32 digest = cheats.eip712HashTypedData(json);
+```
+
+### SEE ALSO
+
+- [eip712HashType](/docs/reference/cheatcodes/utilities/eip712-hash-type)
+- [eip712HashStruct](/docs/reference/cheatcodes/utilities/eip712-hash-struct)
+- [EIP-712 type hashing guide](/docs/guides/testing/eip712-types)

--- a/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-typed-data.mdx
+++ b/src/content/docs/docs/reference/cheatcodes/Utilities/eip712-hash-typed-data.mdx
@@ -6,8 +6,9 @@ description: eip712HashTypedData cheatcode documentation
 ### Signature
 
 ```solidity
-function eip712HashTypedData(string calldata jsonData)
-    external pure returns (bytes32);
+function eip712HashTypedData(
+  string calldata jsonData
+) external pure returns (bytes32);
 ```
 
 ### Description

--- a/src/content/docs/docs/reference/cheatcodes/unsupported-cheatcodes.mdx
+++ b/src/content/docs/docs/reference/cheatcodes/unsupported-cheatcodes.mdx
@@ -9,12 +9,6 @@ The following Solidity test cheatcodes are currently not supported in Hardhat:
 
 - `breakpoint`
 
-### EIP-712 cheatcodes
-
-- `eip712HashStruct`
-- `eip712HashType`
-- `eip712HashTypedData`
-
 ### EIP-7702 cheatcodes
 
 - `attachDelegation`

--- a/src/content/docs/docs/reference/configuration.mdx
+++ b/src/content/docs/docs/reference/configuration.mdx
@@ -271,6 +271,9 @@ If write access to a directory is needed, please make sure that it doesn't conta
 - `coinbase`: The value of `block.coinbase` in tests. Defaults to `0x0000000000000000000000000000000000000000`.
 - `blockTimestamp`: The value of `block.timestamp` in tests. Defaults to 1.
 - `blockGasLimit`: The `block.gaslimit` value during EVM execution. Set it to false to disable the block gas limit. Defaults to none.
+- `eip712Types`: Optional object to configure EIP-712 type collection for the [`eip712HashType`](/docs/reference/cheatcodes/utilities/eip712-hash-type) and [`eip712HashStruct`](/docs/reference/cheatcodes/utilities/eip712-hash-struct) cheatcodes. Disabled by default. See the [EIP-712 type hashing guide](/docs/guides/testing/eip712-types) for details.
+  - `include`: An array of glob patterns matching source files to collect EIP-712 struct types from. Required to enable type collection. Supports `*`, `**`, and `?` wildcards.
+  - `exclude`: An optional array of glob patterns matching source files to exclude from type collection.
 - `forking`: Optional fork configuration options object. Defaults to none.
   - `url`: If set, all tests are run in fork mode using this url or remote name. Defaults to none.
   - `blockNumber`: Optional block number to pin the global state fork. If `url` is set, defaults to the latest block number.


### PR DESCRIPTION
Docs for Hardhat PR: https://github.com/NomicFoundation/hardhat/pull/8243

Links to modified pages in the preview webiste:
- hh configuration: https://hardhat-website-git-eip-712-cheatcodes-hh-nomic-foundation.vercel.app/docs/reference/configuration
- eip712-types: https://hardhat-website-git-eip-712-cheatcodes-hh-nomic-foundation.vercel.app/docs/guides/testing/eip712-types
- eip712-hash-type: https://hardhat-website-git-eip-712-cheatcodes-hh-nomic-foundation.vercel.app/docs/reference/cheatcodes/utilities/eip712-hash-type
- eip712-hash-struct: https://hardhat-website-git-eip-712-cheatcodes-hh-nomic-foundation.vercel.app/docs/reference/cheatcodes/utilities/eip712-hash-struct
- eip712-hash-typed-data: https://hardhat-website-git-eip-712-cheatcodes-hh-nomic-foundation.vercel.app/docs/reference/cheatcodes/utilities/eip712-hash-typed-data