### PR TITLE
docs: clarify Node.js v22.13.0 minimum and note Alpine Docker gotcha

### DIFF
--- a/src/content/docs/docs/getting-started.mdx
+++ b/src/content/docs/docs/getting-started.mdx
@@ -21,7 +21,8 @@ This guide will walk you through installing our recommended setup, but since mos
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) v22 or later
+- [Node.js](https://nodejs.org/) v22.13.0 or later
+  - For Docker users: the plain `node:22-alpine` tag is not guaranteed to ship Node.js ≥ 22.13.0. Pin a specific patch tag (e.g. `node:22.13-alpine`) to avoid version-check failures.
 - A package manager like [npm](https://www.npmjs.com/), [pnpm](https://pnpm.io/), or [yarn](https://yarnpkg.com/) (we strongly recommend pnpm)
 - A text editor (we recommend [VS Code](https://code.visualstudio.com/) with our [Official Hardhat extension](https://marketplace.visualstudio.com/items?itemName=NomicFoundation.hardhat-solidity))
 


### PR DESCRIPTION
## Summary

Updates the Hardhat 3 Getting Started page to match the Node.js version that the CLI actually enforces, and adds a short note for Docker users.

## Why

The current docs say:

> Node.js v22 or later

But the Hardhat 3 CLI enforces a stricter minimum in source:

```ts
// packages/hardhat/src/internal/cli/node-version.ts
export const MIN_SUPPORTED_NODE_VERSION: number[] = [22, 13, 0];
```

A user following the docs literally — for example by pulling `node:22-alpine` or installing Node 22.10.x — falls inside the documented range but hits a runtime error from the version check. The Alpine case is especially common because the plain `node:22-alpine` tag is not guaranteed to ship the latest patch version.

Issue: NomicFoundation/hardhat#8293

## Change

`src/content/docs/docs/getting-started.mdx`:

- Tighten the Node version from `v22 or later` to `v22.13.0 or later`.
- Add a sub-bullet recommending Docker users pin a specific patch tag (e.g. `node:22.13-alpine`).

## Notes

Trivial markdown change — no local build run. Indentation matches the existing nested-bullet style elsewhere in the docs. Happy to amend the wording or move the Docker note into a `:::tip` callout if maintainers prefer.
