### PR TITLE
Add hardhat-descriptor to community plugins

### DIFF
--- a/src/content/community-plugins.json
+++ b/src/content/community-plugins.json
@@ -133,6 +133,13 @@
       "authorUrl": "https://github.com/openscan-explorer/hardhat-plugin",
       "description": "Hardhat plugin to explore the hardhat network, blocks, txs, contracts, etc.",
       "tags": ["Devtools", "Testing"]
+    },
+    {
+      "name": "hardhat-descriptor",
+      "author": "hangleang",
+      "authorUrl": "https://github.com/hangleang",
+      "description": "Generate ERC-7730 clear-signing descriptors for compiled contracts using Claude, Gemini, or any OpenAI-compatible LLM.",
+      "tags": ["erc-7730", "clear-signing"]
     }
   ]
 }


### PR DESCRIPTION
Adds [hardhat-descriptor](https://www.npmjs.com/package/hardhat-descriptor) to the community plugins list.

**What it does:** Generates [ERC-7730](https://eips.ethereum.org/EIPS/eip-7730) clear-signing descriptors for compiled contracts using an LLM (Anthropic Claude, Google Gemini, or any OpenAI-compatible endpoint). The generated JSON tells wallets like Ledger, Trezor, and WalletConnect how to render contract calls and EIP-712 typed-data signatures as human-readable intents.

- npm: https://www.npmjs.com/package/hardhat-descriptor
- Repo: https://github.com/hangleang/hardhat-descriptor
- License: GPL-3.0-or-later
- Hardhat 3 compatible (peer dependency `hardhat@^3.0.0`)