### PR TITLE
docs: add dedicated ESM migration guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@astrojs/vercel": "^8.2.8",
     "@expressive-code/plugin-collapsible-sections": "^0.41.3",
     "@expressive-code/plugin-line-numbers": "^0.41.3",
-    "@nomicfoundation/hardhat-errors": "^3.0.12",
+    "@nomicfoundation/hardhat-errors": "^3.0.13",
     "@types/tar-stream": "^3.1.4",
     "astro": "^5.6.1",
     "cspell": "^9.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^0.41.3
         version: 0.41.3
       '@nomicfoundation/hardhat-errors':
-        specifier: ^3.0.12
-        version: 3.0.12
+        specifier: ^3.0.13
+        version: 3.0.13
       '@types/tar-stream':
         specifier: ^3.1.4
         version: 3.1.4
@@ -767,11 +767,11 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/hardhat-errors@3.0.12':
-    resolution: {integrity: sha512-2viEq1D19FHWKpfB2vVeL0R6d+iZR2E5h0EhKQQMc1ukDUV2fel/7fRjlWuCOx2CFC+5mHL2saRcN8KlYsX8hg==}
+  '@nomicfoundation/hardhat-errors@3.0.13':
+    resolution: {integrity: sha512-h0nWNzKbmP6XhINMgSUfGixevzksT8BQPK08KNnsr/8kQORAeYzsv6bf0CLUD8mZfmBEP45m4QMlNP6xcoc0Ow==}
 
-  '@nomicfoundation/hardhat-utils@4.1.0':
-    resolution: {integrity: sha512-qze9X5P8LIB36rjS3cFhD7asG82pjZDmJAYfCQBSDhMYJM1HDZrYKgKfJLEE36TmrhjgQ/hlNO0DikDq0e2VYg==}
+  '@nomicfoundation/hardhat-utils@4.1.2':
+    resolution: {integrity: sha512-jUQfbyIoTLHmSua+BMhIqUIk7uDwL2bhTtJgfwRoVooM3TTvm5rIdRK+eNkvZcZR/wAL/SBQOq/r9yOekj4Unw==}
 
   '@nomicfoundation/slang@1.2.0':
     resolution: {integrity: sha512-+04Z1RHbbz0ldDbHKQFOzveCdI9Rd3TZZu7fno5hHy3OsqTo9UK5Jgqo68wMvRovCO99POv6oCEyO7+urGeN8Q==}
@@ -3783,11 +3783,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nomicfoundation/hardhat-errors@3.0.12':
+  '@nomicfoundation/hardhat-errors@3.0.13':
     dependencies:
-      '@nomicfoundation/hardhat-utils': 4.1.0
+      '@nomicfoundation/hardhat-utils': 4.1.2
 
-  '@nomicfoundation/hardhat-utils@4.1.0':
+  '@nomicfoundation/hardhat-utils@4.1.2':
     dependencies:
       '@streamparser/json-node': 0.0.22
       env-paths: 2.2.1

--- a/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
@@ -1,0 +1,122 @@
+---
+title: Migrate your project to ESM
+description: How to convert a Hardhat project from CommonJS to ES modules
+sidebar:
+  label: Migrate to ESM
+---
+
+import { TabItem, Tabs } from "@astrojs/starlight/components";
+import { Code } from "@astrojs/starlight/components";
+
+Hardhat 3 is ESM-first, so your project needs to be an ES module. This guide walks you through converting an existing CommonJS project to ESM, and shows the escape hatches for keeping individual files as CommonJS when that's easier.
+
+:::tip
+
+If you landed here from a Hardhat error message, you're in the right place. Jump to [Troubleshooting](#troubleshooting) to match the specific error to a fix.
+
+:::
+
+## Set your project to ESM
+
+Add `"type": "module"` to your `package.json`:
+
+{/* prettier-ignore */}
+<Tabs syncKey="package-manager">
+  <TabItem label="npm" icon="npm">
+    <Code code="npm pkg set type=module" lang="sh" frame="terminal" />
+  </TabItem>
+  <TabItem label="pnpm" icon="pnpm">
+    <Code code="pnpm pkg set type=module" lang="sh" frame="terminal" />
+  </TabItem>
+  <TabItem label="Yarn" icon="seti:yarn">
+    <Code code={`# yarn doesn't have a command for this\nnpm pkg set type=module`} lang="sh" frame="terminal" />
+  </TabItem>
+</Tabs>
+
+From this point on, every `.js` file in your project is treated as an ES module.
+
+## Update your TypeScript config
+
+If you have a `tsconfig.json`, set `compilerOptions.module` to an ESM-compatible value like `"node16"`:
+
+```json
+{
+  "compilerOptions": {
+    "module": "node16"
+  }
+}
+```
+
+## Convert source files to ESM
+
+[This guide](https://deno.com/blog/convert-cjs-to-esm) covers the conversion in depth, but the rules you'll hit most often are:
+
+- Replace `const x = require("x")` with `import x from "x"`.
+- When importing a relative path, you must include the file extension. `const x = require("./x")` becomes `import x from "./x.js"`, not `import x from "./x"`.
+- Replace `module.exports = x` with `export default x`, and `module.exports.x = 1` with `export const x = 1`.
+- `__dirname` and `__filename` are now `import.meta.dirname` and `import.meta.filename`.
+
+For example, a CommonJS script like this:
+
+```js
+const path = require("path");
+const helper = require("./helper");
+
+module.exports = function run() {
+  console.log(path.join(__dirname, helper.name));
+};
+```
+
+becomes:
+
+```js
+import path from "path";
+import helper from "./helper.js";
+
+export default function run() {
+  console.log(path.join(import.meta.dirname, helper.name));
+}
+```
+
+## Keeping files as CommonJS
+
+If converting a file is impractical, rename it from `.js` to `.cjs`. CommonJS files keep working alongside ESM ones, and you don't have to change their syntax.
+
+**We still recommend writing new files in ESM** to take advantage of modern JavaScript features and match Hardhat 3's defaults.
+
+## Using Hardhat from a CommonJS file
+
+You can't `require("hardhat")` at the top level of a `.cjs` file, because Hardhat is an ES module. Use a dynamic `import` from inside an async function instead:
+
+```js
+async function main() {
+  const hre = await import("hardhat");
+  // use hre
+}
+
+main();
+```
+
+If you're using Hardhat from a Mocha test, the same pattern applies inside a `before` hook. See the [Mocha tests migration guide](/docs/migrate-from-hardhat2/guides/mocha-tests) for an example.
+
+## Troubleshooting
+
+If a Hardhat command failed with one of the errors below, here's what's happening and how to fix it.
+
+### `__dirname is not defined in ES module scope`
+
+A file is now being treated as ESM, but it still uses the CommonJS-only `__dirname` (or `__filename`).
+
+Replace those with `import.meta.dirname` and `import.meta.filename`. See [Convert source files to ESM](#convert-source-files-to-esm) for the other syntax differences you may need to address.
+
+### `Cannot use import statement outside a module`
+
+Node.js is loading a file as CommonJS, but the file uses `import` syntax.
+
+Either set `"type": "module"` in `package.json` so `.js` files are loaded as ESM (see [Set your project to ESM](#set-your-project-to-esm)), or rename the file to `.mjs`.
+
+### `require() of ES module ...`
+
+A CommonJS file is trying to `require()` an ES module. The most common case is `require("hardhat")` from a `.cjs` file.
+
+Convert the file that's calling `require()` to ESM, or load the ES module with a dynamic `await import()`. See [Using Hardhat from a CommonJS file](#using-hardhat-from-a-commonjs-file) for the pattern.

--- a/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
@@ -8,7 +8,7 @@ sidebar:
 import { TabItem, Tabs } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 
-Hardhat 3 is ESM-first, so your project needs to be an ES module. This guide walks you through converting an existing CommonJS project to ESM, and shows the escape hatches for keeping individual files as CommonJS when that's easier.
+Hardhat 3 is ESM-first, so your project needs to be an ESM package. This guide walks you through converting an existing CommonJS project to ESM, and shows the escape hatches for keeping individual files as CommonJS when that's easier.
 
 :::tip
 

--- a/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
@@ -37,7 +37,7 @@ From this point on, every `.js` file in your project is treated as an ES module.
 
 ## Update your TypeScript config
 
-If you have a `tsconfig.json`, set `compilerOptions.module` to an ESM-compatible value like `"node16"`:
+If you have a `tsconfig.json`, set `compilerOptions.module` to an ESM-compatible value like `"node20"`:
 
 ```json
 {

--- a/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
@@ -42,7 +42,7 @@ If you have a `tsconfig.json`, set `compilerOptions.module` to an ESM-compatible
 ```json
 {
   "compilerOptions": {
-    "module": "node16"
+    "module": "node20"
   }
 }
 ```

--- a/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
@@ -90,7 +90,7 @@ You can't `require("hardhat")` at the top level of a `.cjs` file, because Hardha
 
 ```js
 async function main() {
-  const hre = await import("hardhat");
+  const { default: hre } = await import("hardhat");
   // use hre
 }
 

--- a/src/content/docs/docs/migrate-from-hardhat2/guides/mocha-tests.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/guides/mocha-tests.mdx
@@ -17,7 +17,7 @@ If you keep your tests as CommonJS, you can't `require("hardhat")` at the top le
 describe("suite", function () {
   let hre;
   before(async function () {
-    hre = await import("hardhat");
+    ({ default: hre } = await import("hardhat"));
   });
 
   it("some test", async function () {

--- a/src/content/docs/docs/migrate-from-hardhat2/guides/mocha-tests.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/guides/mocha-tests.mdx
@@ -9,34 +9,9 @@ This guide walks you through the changes needed to migrate your Mocha tests from
 
 ## ESM
 
-Since Hardhat 3 is ESM-first, files with a `.js` extension are treated as ES modules. If your tests are written in JavaScript, this means you have to update them to use ESM syntax or change their extension to `.cjs`.
+Hardhat 3 is ESM-first, so JavaScript test files (`.js`) are treated as ES modules. See the [ESM migration guide](/docs/migrate-from-hardhat2/guides/migrate-to-esm) for the conversion steps, or for how to keep your tests as CommonJS with a `.cjs` extension.
 
-### Updating the syntax to ESM
-
-Check [this guide](https://deno.com/blog/convert-cjs-to-esm) to learn how to convert CommonJS code to ESM, but here's a summary:
-
-- Convert statements like `const x = require("x")` to `import x from "x"`.
-- When importing a relative path, you always have to include the file extension. For example, `const x = require("./x")` becomes `import x from "./x.js"`, not `import x from "./x"`.
-- Convert `module.exports = x` to `export default x` and `module.exports.x = 1` to `export const x = 1`.
-- `__dirname` and `__filename` are now available as `import.meta.dirname` and `import.meta.filename`.
-
-### Changing the extension to .cjs
-
-Alternatively, you can rename your test files so that they have a `.cjs` extension. This way, they will be treated as CommonJS modules and you won't have to change any syntax. **We still recommend writing new tests in ESM** to take advantage of modern JavaScript features and match Hardhat 3's defaults.
-
-If you go with the `.cjs` approach, keep in mind that you can't require Hardhat as a top-level module. This code:
-
-```js
-const hre = require("hardhat");
-
-describe("suite", function () {
-  it("some test", async function () {
-    // use the hre
-  });
-});
-```
-
-has to be changed to:
+If you keep your tests as CommonJS, you can't `require("hardhat")` at the top level. Use a dynamic `import` from a `before` hook instead:
 
 ```js
 describe("suite", function () {
@@ -45,20 +20,6 @@ describe("suite", function () {
     hre = await import("hardhat");
   });
 
-  it("some test", async function () {
-    // use the hre
-  });
-});
-```
-
-Notice that this can only be done inside async functions.
-
-If you migrated to ESM instead, that would be:
-
-```js
-import hre from "hardhat";
-
-describe("suite", function () {
   it("some test", async function () {
     // use the hre
   });

--- a/src/content/docs/docs/migrate-from-hardhat2/index.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/index.mdx
@@ -5,8 +5,6 @@ sidebar:
   label: Overview
 ---
 
-import { TabItem, Tabs } from "@astrojs/starlight/components";
-import { Code } from "@astrojs/starlight/components";
 import Install from "@hh/Install.astro";
 import Run from "@hh/Run.astro";
 
@@ -64,24 +62,9 @@ Before making any changes, prepare your project so that installing and running H
     mv hardhat.config.js hardhat.config.old.js
     ```
 
-5.  **Make your project ESM**
+5.  **Convert your project to ESM**
 
-    {/* prettier-ignore */}
-    <Tabs syncKey="package-manager">
-      <TabItem label="npm" icon="npm">
-        <Code code="npm pkg set type=module" lang="sh" frame="terminal" />
-      </TabItem>
-      <TabItem label="pnpm" icon="pnpm">
-        <Code code="pnpm pkg set type=module" lang="sh" frame="terminal" />
-      </TabItem>
-      <TabItem label="Yarn" icon="seti:yarn">
-        <Code code={`# yarn doesn't have a command for this\nnpm pkg set type=module`} lang="sh" frame="terminal" />
-      </TabItem>
-    </Tabs>
-
-6.  **(Optional) Adapt your `tsconfig.json`**
-
-    If you have a `tsconfig.json` file, make sure that `compilerOptions.module` is set to an ESM-compatible value like `"node16"`.
+    Hardhat 3 requires your project to be an ES module. Follow the [ESM migration guide](/docs/migrate-from-hardhat2/guides/migrate-to-esm) to set `"type": "module"` in your `package.json`, update your `tsconfig.json` if you have one, and convert any files you need to.
 
 ## Setting up Hardhat 3
 

--- a/src/redirects/in-app-shortlinks.ts
+++ b/src/redirects/in-app-shortlinks.ts
@@ -25,6 +25,5 @@ export default [
   ["/getting-started", "/docs/getting-started"],
   ["/foundry-compatibility", "/docs/reference/foundry-compatibility"],
   ["/migrate-from-hardhat2", "/docs/migrate-from-hardhat2"],
-  // Bump this target to a dedicated CommonJS→ESM guide once it lands.
-  ["/migrate-to-esm", "/docs/migrate-from-hardhat2/guides/mocha-tests#esm"],
+  ["/migrate-to-esm", "/docs/migrate-from-hardhat2/guides/migrate-to-esm"],
 ] satisfies Redirects;

--- a/test/utils/generateMarkdown.test.ts
+++ b/test/utils/generateMarkdown.test.ts
@@ -69,12 +69,13 @@ describe("generateMarkdown", () => {
     assert.ok(!result.includes("Components used in this page:"));
   });
 
-  it("handles real .mdx with components (migrate-from-hardhat2)", () => {
-    const filePath = "src/content/docs/docs/migrate-from-hardhat2/index.mdx";
+  it("handles real .mdx with components (migrate-to-esm)", () => {
+    const filePath =
+      "src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx";
     const { title, description, body } = parseMdx(filePath);
     const result = generateMarkdown({ title, description, body, filePath });
 
-    assert.ok(result.includes("# Migrate from Hardhat 2"));
+    assert.ok(result.includes("# Migrate your project to ESM"));
     assert.ok(result.includes("Note: This document was authored using MDX"));
     assert.ok(
       result.includes(


### PR DESCRIPTION
## Summary
- New how-to at `/docs/migrate-from-hardhat2/guides/migrate-to-esm` covering project setup, syntax conversion, `.cjs` opt-out, dynamic-importing Hardhat from CJS, plus a troubleshooting section mapping the three CJS->ESM markers the CLI classifier matches to their fixes.
- `/migrate-to-esm` short link now points at the new page.
- Removes the duplicated ESM material from the migration index and the Mocha tests guide.