### PR TITLE
docs: update plugin examples to use definePlugin

### DIFF
--- a/src/content/docs/docs/plugin-development/explanations/hooks.mdx
+++ b/src/content/docs/docs/plugin-development/explanations/hooks.mdx
@@ -38,7 +38,7 @@ Some examples of Hook Categories are:
 
 A Hook Handler is a function that is executed when a Hook is run. They are defined by plugins and implement their custom logic. You can think of them as callbacks that implement a Hook's type and are executed when the Hook runs.
 
-Most Hook Handlers are defined in the [`HardhatPlugin`'s `hookHandlers` property](/docs/plugin-development/reference/hardhat-plugin-object#hookhandlers) and only loaded when needed. To learn more about their lifecycle, read the [Lifecycle of the components of a Hardhat 3 plugin](/docs/plugin-development/explanations/lifecycle) explanation.
+Most Hook Handlers are defined in the [plugin's `hookHandlers` property](/docs/plugin-development/reference/hardhat-plugin-object#hookhandlers) and only loaded when needed.
 
 ## Different types of Hooks
 

--- a/src/content/docs/docs/plugin-development/explanations/lifecycle.mdx
+++ b/src/content/docs/docs/plugin-development/explanations/lifecycle.mdx
@@ -14,7 +14,7 @@ The lifecycle of a Hardhat plugin can be divided into two parts: importing the p
 
 ### Plugin import
 
-A Hardhat 3 plugin is a TypeScript object with the `HardhatPlugin` type. It can be defined in any `.ts` file, but it's usually defined in the `index.ts` file of the plugin's package and exported as `default`.
+A Hardhat 3 plugin is defined using `definePlugin` from `hardhat/plugins`. It can be defined in any `.ts` file, but it's usually defined in the `index.ts` file of the plugin's package and exported as `default`.
 
 Importing it shouldn't generate any side effects at runtime or import anything other than Hardhat and the plugin's [Type Extensions](/docs/plugin-development/explanations/type-extensions). All the actual behavior must be in separate files that are loaded dynamically.
 
@@ -22,12 +22,12 @@ For example, the `index.ts` file of the [Hardhat 3 plugin template](https://gith
 
 ```ts
 import { task } from "hardhat/config";
+import { definePlugin } from "hardhat/plugins";
 import { ArgumentType } from "hardhat/types/arguments";
-import type { HardhatPlugin } from "hardhat/types/plugins";
 
 import "./type-extensions.js";
 
-const plugin: HardhatPlugin = {
+const plugin = definePlugin({
   id: "hardhat-my-plugin",
   hookHandlers: {
     config: () => import("./hooks/config.js"),
@@ -44,7 +44,7 @@ const plugin: HardhatPlugin = {
       .setAction(() => import("./tasks/my-task.js"))
       .build(),
   ],
-};
+});
 ```
 
 Importing this file only loads Hardhat's modules and the type extensions.

--- a/src/content/docs/docs/plugin-development/explanations/lifecycle.mdx
+++ b/src/content/docs/docs/plugin-development/explanations/lifecycle.mdx
@@ -14,7 +14,7 @@ The lifecycle of a Hardhat plugin can be divided into two parts: importing the p
 
 ### Plugin import
 
-A Hardhat 3 plugin is defined using `definePlugin` from `hardhat/plugins`. It can be defined in any `.ts` file, but it's usually defined in the `index.ts` file of the plugin's package and exported as `default`.
+A Hardhat 3 plugin is created with `definePlugin` from `hardhat/plugins`. It can be defined in any `.ts` file, but it's usually defined in the `index.ts` file of the plugin's package and exported as `default`.
 
 Importing it shouldn't generate any side effects at runtime or import anything other than Hardhat and the plugin's [Type Extensions](/docs/plugin-development/explanations/type-extensions). All the actual behavior must be in separate files that are loaded dynamically.
 

--- a/src/content/docs/docs/plugin-development/guides/dependencies.mdx
+++ b/src/content/docs/docs/plugin-development/guides/dependencies.mdx
@@ -18,17 +18,15 @@ To use another plugin as a dependency, you need to:
 Here's how a plugin that depends on `another-plugin` would look:
 
 ```ts
-import type { HardhatPlugin } from "hardhat/types/plugins";
+import { definePlugin } from "hardhat/plugins";
 
 import "./type-extensions.js";
 
-const plugin: HardhatPlugin = {
+export default definePlugin({
   id: "hardhat-my-plugin",
   dependencies: () => [import("another-plugin")],
   // ...
-};
-
-export default plugin;
+});
 ```
 
 When you declare a plugin as a dependency, its Hook Handlers, Tasks, and Global Options will be loaded before your plugin's.

--- a/src/content/docs/docs/plugin-development/guides/dependencies.mdx
+++ b/src/content/docs/docs/plugin-development/guides/dependencies.mdx
@@ -13,7 +13,7 @@ To use another plugin as a dependency, you need to:
 
 1. Declare it as a `peerDependency` and `devDependency` in your `package.json` file
 2. Declare any peer dependencies of that plugin as peer and dev dependencies in your own `package.json` file
-3. Add it to the `dependencies` field of your `HardhatPlugin` object
+3. Add it to the `dependencies` field of your plugin
 
 Here's how a plugin that depends on `another-plugin` would look:
 

--- a/src/content/docs/docs/plugin-development/guides/publishing.mdx
+++ b/src/content/docs/docs/plugin-development/guides/publishing.mdx
@@ -46,7 +46,7 @@ You don't need to follow any specific process to publish your plugin, but here a
 When you publish your plugin as a separate package, follow these two steps:
 
 1. Make sure your [plugin's `id`](/docs/plugin-development/reference/hardhat-plugin-object#id) matches the package name
-2. Define the [main entry point in your `package.json` file](https://nodejs.org/api/packages.html#main-entry-point-export) to point to the module that exports your `HardhatPlugin` object as `default`.
+2. Define the [main entry point in your `package.json` file](https://nodejs.org/api/packages.html#main-entry-point-export) to point to the module that exports your plugin as `default`.
 
 This lets users import your plugin like this:
 

--- a/src/content/docs/docs/plugin-development/index.mdx
+++ b/src/content/docs/docs/plugin-development/index.mdx
@@ -11,16 +11,16 @@ Welcome to the Hardhat plugin development documentation. In this section, you'll
 
 A Hardhat plugin is a reusable extension of the functionality of Hardhat and its plugins.
 
-Plugins are defined as TypeScript objects with a `HardhatPlugin` type. Users add them to the `plugins` array in their `hardhat.config.ts` file.
+Plugins are defined using `definePlugin` from `hardhat/plugins`. Users add them to the `plugins` array in their `hardhat.config.ts` file.
 
 Let's look at the structure of a basic plugin:
 
 ```ts
-import type { HardhatPlugin } from "hardhat/types/plugins";
+import { definePlugin } from "hardhat/plugins";
 
 import "./type-extensions.js";
 
-const plugin: HardhatPlugin = {
+export default definePlugin({
   id: "hardhat-my-plugin",
   hookHandlers: {
     // The hook handlers that this plugin defines
@@ -37,9 +37,7 @@ const plugin: HardhatPlugin = {
   conditionalDependencies: [
     // Plugins that are loaded only if the user is already using certain other plugins
   ],
-};
-
-export default plugin;
+});
 ```
 
 A plugin can define:

--- a/src/content/docs/docs/plugin-development/reference/hardhat-plugin-object.mdx
+++ b/src/content/docs/docs/plugin-development/reference/hardhat-plugin-object.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-This document explains the `HardhatPlugin` type, which is used to define a Hardhat 3 plugin.
+This document explains the `HardhatPlugin` type, which is used to define a Hardhat 3 plugin. You typically create a value of this type with `definePlugin` from `hardhat/plugins`.
 
 This is how its TypeScript interface looks:
 

--- a/src/content/docs/docs/plugin-development/tutorial/task.mdx
+++ b/src/content/docs/docs/plugin-development/tutorial/task.mdx
@@ -7,9 +7,9 @@ sidebar:
 
 Let's now define a task that prints the `myAccount` address of the network Hardhat is connected to, with a customizable title.
 
-## Defining the task in your `HardhatPlugin` object
+## Defining the task in your plugin
 
-Tasks are defined in the `tasks` property of the `HardhatPlugin` object.
+Tasks are defined in the `tasks` property of your plugin.
 
 If you open `packages/plugin/src/index.ts`, you'll find the `tasks` property, an array of task definitions. You already have one:
 


### PR DESCRIPTION
## Summary

Updates the plugin development documentation to use the `definePlugin()` helper introduced in [#8339](https://github.com/NomicFoundation/hardhat/pull/8339), replacing the old `const plugin: HardhatPlugin = {...}` pattern.

- **`plugin-development/index.mdx`**: Updated the basic plugin structure example and the introductory prose
- **`plugin-development/explanations/lifecycle.mdx`**: Updated the prose description and the `index.ts` code example
- **`plugin-development/guides/dependencies.mdx`**: Updated the plugin dependency example

Closes NomicFoundation/hardhat#8340

## Test plan

- [ ] Review that all three changed code blocks compile correctly with the new import (`definePlugin` from `"hardhat/plugins"`)
- [ ] Verify prose reads naturally with the updated descriptions