### PR TITLE
feat: skip file support in configuration

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -78,3 +78,4 @@ llms
 lockfiles
 gitmodules
 resumability
+uninstrumented

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@astrojs/vercel": "^8.2.8",
     "@expressive-code/plugin-collapsible-sections": "^0.41.3",
     "@expressive-code/plugin-line-numbers": "^0.41.3",
-    "@nomicfoundation/hardhat-errors": "^3.0.13",
+    "@nomicfoundation/hardhat-errors": "^3.0.15",
     "@types/tar-stream": "^3.1.4",
     "astro": "^5.6.1",
     "cspell": "^9.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^0.41.3
         version: 0.41.3
       '@nomicfoundation/hardhat-errors':
-        specifier: ^3.0.13
-        version: 3.0.13
+        specifier: ^3.0.15
+        version: 3.0.15
       '@types/tar-stream':
         specifier: ^3.1.4
         version: 3.1.4
@@ -767,11 +767,11 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/hardhat-errors@3.0.13':
-    resolution: {integrity: sha512-h0nWNzKbmP6XhINMgSUfGixevzksT8BQPK08KNnsr/8kQORAeYzsv6bf0CLUD8mZfmBEP45m4QMlNP6xcoc0Ow==}
+  '@nomicfoundation/hardhat-errors@3.0.15':
+    resolution: {integrity: sha512-h3r32RzpmWEcB2bz6aqZKlKOP8tzyvHLkPFleFFqwVvjO5AUfSoMUxm8OjaTuNgPF35mXPYRISh+kNCwmsKVOA==}
 
-  '@nomicfoundation/hardhat-utils@4.1.2':
-    resolution: {integrity: sha512-jUQfbyIoTLHmSua+BMhIqUIk7uDwL2bhTtJgfwRoVooM3TTvm5rIdRK+eNkvZcZR/wAL/SBQOq/r9yOekj4Unw==}
+  '@nomicfoundation/hardhat-utils@4.1.3':
+    resolution: {integrity: sha512-SYDKX6SCdzs/5mC/S1D+AjNSQJrhxevHTI24TIouIjO0Xs0dB0+S4cYCqHWOgvnHLshrcrJ7XGUjS7+apWa1Tw==}
 
   '@nomicfoundation/slang@1.2.0':
     resolution: {integrity: sha512-+04Z1RHbbz0ldDbHKQFOzveCdI9Rd3TZZu7fno5hHy3OsqTo9UK5Jgqo68wMvRovCO99POv6oCEyO7+urGeN8Q==}
@@ -3783,11 +3783,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nomicfoundation/hardhat-errors@3.0.13':
+  '@nomicfoundation/hardhat-errors@3.0.15':
     dependencies:
-      '@nomicfoundation/hardhat-utils': 4.1.2
+      '@nomicfoundation/hardhat-utils': 4.1.3
 
-  '@nomicfoundation/hardhat-utils@4.1.2':
+  '@nomicfoundation/hardhat-utils@4.1.3':
     dependencies:
       '@streamparser/json-node': 0.0.22
       env-paths: 2.2.1

--- a/src/content/docs/docs/reference/configuration.mdx
+++ b/src/content/docs/docs/reference/configuration.mdx
@@ -292,6 +292,25 @@ If write access to a directory is needed, please make sure that it doesn't conta
   - `includePushBytes`: The flag indicating whether to include push bytes values. Defaults to true.
   - `shrinkRunLimit`: The maximum number of attempts to shrink a failed sequence. The shrink process is disabled if set to 0. Defaults to 5000.
 
+### Coverage configuration
+
+Hardhat has built-in [code coverage](/docs/guides/testing/code-coverage). You can use the `coverage` entry to configure it:
+
+```ts
+// hardhat.config.ts
+import { defineConfig } from "hardhat/config";
+
+export default defineConfig({
+  coverage: {
+    skipFiles: ["**/mocks/**", "contracts/Migrations.sol"],
+  },
+});
+```
+
+The following options are available for configuring coverage:
+
+- `skipFiles`: An array of glob patterns matching Solidity files to exclude from coverage during a `--coverage` run. A matching file is left uninstrumented, so it doesn't appear in the coverage report. Patterns are matched against each file's source name — its project-relative path as shown in the coverage report, e.g. `contracts/Migrations.sol` — not its absolute path. Supports `*`, `**`, and `?` wildcards. Defaults to `[]`.
+
 ## Toolbox options
 
 Hardhat provides two official toolboxes, each with a set of plugins meant to simplify setup: [`hardhat-toolbox-viem`](/docs/plugins/hardhat-toolbox-viem) and [`hardhat-toolbox-mocha-ethers`](/docs/plugins/hardhat-toolbox-mocha-ethers).


### PR DESCRIPTION
Include the new `coverage` section of the config with its support for `skipFiles`.

Part of https://github.com/NomicFoundation/hardhat/pull/8380.