### PR TITLE
hardhat3 website: add Hardhat 2 end of life page

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -79,3 +79,5 @@ lockfiles
 gitmodules
 resumability
 uninstrumented
+Glamsterdam
+Hegota

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1677,10 +1677,6 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-equals@5.3.2:
-    resolution: {integrity: sha512-6rxyATwPCkaFIL3JLqw8qXqMpIZ942pTX/tbQFkRsDGblS8tNGtlUauA/+mt6RUfqn/4MoEr+WDkYoIQbibWuQ==}
-    engines: {node: '>=6.0.0'}
-
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
@@ -4482,7 +4478,7 @@ snapshots:
       '@cspell/cspell-pipe': 9.2.2
       '@cspell/cspell-types': 9.2.2
       cspell-trie-lib: 9.2.2
-      fast-equals: 5.3.2
+      fast-equals: 5.4.0
 
   cspell-gitignore@9.2.2:
     dependencies:
@@ -4739,8 +4735,6 @@ snapshots:
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
-
-  fast-equals@5.3.2: {}
 
   fast-equals@5.4.0: {}
 

--- a/src/content/docs/docs/reference/hardhat-2-end-of-life.mdx
+++ b/src/content/docs/docs/reference/hardhat-2-end-of-life.mdx
@@ -1,0 +1,46 @@
+---
+title: Hardhat 2 end of life
+description: Hardhat 3 is stable and production ready. Hardhat 2 will be maintained until its end-of-life date — start planning your migration today.
+---
+
+:::tip[Hardhat 2 is reaching end of life and is being replaced by Hardhat 3]
+**Hardhat 3 is stable and production ready**, and teams are already migrating.
+Hardhat 2 will be upgraded to support the Glamsterdam hardfork and will continue
+to receive bug fixes and security fixes until its **end of life** — the earlier
+of **the Hegota mainnet activation** or the **1<sup>st</sup> of July 2027**.
+After that, there will be no further Hardhat 2 releases.
+
+**Plan your migration to Hardhat 3 now**.
+:::
+
+Hardhat 3 is stable and production ready. It's a ground-up rewrite built on a
+Rust-based runtime, with Solidity tests, multi-chain support and many other
+features. To support the changing Node.js ecosystem, Hardhat 3 and its plugin
+system have been redesigned to be ESM native.
+
+Hardhat will always put stability first, which is why Hardhat 3 has spent the
+last 9 months in beta: stabilizing the API, closing bugs and removing migration
+friction for our Hardhat 2 users. Teams across the ecosystem are already moving
+over, see our
+[migration guide](/docs/migrate-from-hardhat2) to join them (or our
+[Foundry migration guide](/docs/migrate-from-foundry) for projects coming
+across).
+
+## Hardhat 2 end of life timeline
+
+We are introducing an **end of life** policy for Hardhat 2, as the Node.js
+ecosystem moves beyond the CommonJS system it uses.
+
+Hardhat 2 will be upgraded to support the **Glamsterdam** hardfork and will
+continue to receive bug fixes and security fixes until it reaches end of life.
+It will **not** be upgraded to the **Hegota** hardfork or any of its EIPs.
+
+Hardhat 2 will reach **end of life** on whichever date comes first between:
+
+- the activation of **the Hegota hardfork** on Ethereum mainnet
+- the **1<sup>st</sup> of July 2027**, if Hegota is delayed
+
+After that date, no further releases should be expected, including for security
+fixes. If you haven't started yet, now is the time to plan your move to
+Hardhat 3. The [Hardhat 2 migration guide](/docs/migrate-from-hardhat2) walks
+you through upgrading an existing project step by step.

--- a/src/content/docs/docs/reference/hardhat-2-end-of-life.mdx
+++ b/src/content/docs/docs/reference/hardhat-2-end-of-life.mdx
@@ -13,10 +13,10 @@ After that, there will be no further Hardhat 2 releases.
 **Plan your migration to Hardhat 3 now**.
 :::
 
-Hardhat 3 is stable and production ready. It's a ground-up rewrite built on a
-Rust-based runtime, with Solidity tests, multi-chain support and many other
-features. To support the changing Node.js ecosystem, Hardhat 3 and its plugin
-system have been redesigned to be ESM native.
+Hardhat 3 is stable and production ready: Solidity tests as first-class,
+multi-chain support, a performant Rust-powered runtime via EDR. To support the
+changing Node.js ecosystem, Hardhat 3 and its plugin system have been redesigned
+to be ESM native.
 
 Hardhat will always put stability first, which is why Hardhat 3 has spent the
 last 9 months in beta: stabilizing the API, closing bugs and removing migration
@@ -42,5 +42,7 @@ Hardhat 2 will reach **end of life** on whichever date comes first between:
 
 After that date, no further releases should be expected, including for security
 fixes. If you haven't started yet, now is the time to plan your move to
-Hardhat 3. The [Hardhat 2 migration guide](/docs/migrate-from-hardhat2) walks
-you through upgrading an existing project step by step.
+Hardhat 3. The
+[Hardhat 2 migration guide](/docs/migrate-from-hardhat2)
+walks you through the upgrade in just a few easy steps, and we are rolling out
+an agent skill soon which can migrate most of your repository automatically.

--- a/src/content/docs/docs/reference/hardhat-2-end-of-life.mdx
+++ b/src/content/docs/docs/reference/hardhat-2-end-of-life.mdx
@@ -7,7 +7,7 @@ description: Hardhat 3 is stable and production ready. Hardhat 2 will be maintai
 **Hardhat 3 is stable and production ready**, and teams are already migrating.
 Hardhat 2 will be upgraded to support the Glamsterdam hardfork and will continue
 to receive bug fixes and security fixes until its **end of life** — the earlier
-of **the Hegota mainnet activation** or the **1<sup>st</sup> of July 2027**.
+of **the Hegota mainnet activation** or the **1<sup>st</sup> of June 2027**.
 After that, there will be no further Hardhat 2 releases.
 
 **Plan your migration to Hardhat 3 now**.

--- a/src/content/docs/docs/reference/hardhat-2-end-of-life.mdx
+++ b/src/content/docs/docs/reference/hardhat-2-end-of-life.mdx
@@ -38,7 +38,7 @@ It will **not** be upgraded to the **Hegota** hardfork or any of its EIPs.
 Hardhat 2 will reach **end of life** on whichever date comes first between:
 
 - the activation of **the Hegota hardfork** on Ethereum mainnet
-- the **1<sup>st</sup> of July 2027**, if Hegota is delayed
+- the **1<sup>st</sup> of June 2027**, if Hegota is delayed
 
 After that date, no further releases should be expected, including for security
 fixes. If you haven't started yet, now is the time to plan your move to

--- a/src/redirects/shortlinks.ts
+++ b/src/redirects/shortlinks.ts
@@ -19,6 +19,7 @@ export default [
   ["/docs", "/docs/getting-started"],
   ["/ignition", "/ignition/docs"],
   ["/ignition/docs", "/ignition/docs/getting-started"],
+  ["/hardhat-2-end-of-life", "/docs/reference/hardhat-2-end-of-life"],
   // This is a temporary workaround because the link validator can't
   // find the #hashes of plugins and fail
   [

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -118,6 +118,7 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
           { slug: "docs/reference/stability-guarantees" },
           { slug: "docs/reference/nodejs-support" },
           { slug: "docs/reference/errors" },
+          { slug: "docs/reference/hardhat-2-end-of-life" },
         ],
       },
       {


### PR DESCRIPTION
Add the Hardhat 2 end of life policy to the Hardhat 3 website.

## Preview

https://hardhat-website-git-end-of-life-nomic-foundation.vercel.app/docs/reference/hardhat-2-end-of-life