### PR TITLE
hardhat2 website: add Hardhat 2 end of life page

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
           path: websites-version-of-hardhat
       - uses: pnpm/action-setup@v3
         with:
-          version: 9
+          version: 10
           run_install: false
       - uses: actions/setup-node@v4
         id: setup-node

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ src/content/hardhat-runner/docs/errors/index.md
 
 # typescript
 *.tsbuildinfo
+
+# Ignore pnpm store in dev container
+.pnpm-store/

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "docs",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "prebuild": "bash scripts/clone-and-build-hardhat.sh && tsx scripts/prepare-error-list.ts",
     "dev": "next-remote-watch ./src/content",

--- a/patches/react@17.0.2.patch
+++ b/patches/react@17.0.2.patch
@@ -1,0 +1,10 @@
+diff --git a/cjs/react-jsx-dev-runtime.production.min.js b/cjs/react-jsx-dev-runtime.production.min.js
+index 02c1a5b3a9aba5378f62d053ce2b5940c3c8d2d5..80d71ceb3a690868d58dc19b698b950bb513efe8 100644
+--- a/cjs/react-jsx-dev-runtime.production.min.js
++++ b/cjs/react-jsx-dev-runtime.production.min.js
+@@ -6,4 +6,4 @@
+  * This source code is licensed under the MIT license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+-'use strict';require("object-assign");require("react");exports.Fragment=60107;if("function"===typeof Symbol&&Symbol.for){var a=Symbol.for;exports.Fragment=a("react.fragment")}exports.jsxDEV=void 0;
++'use strict';require("object-assign");require("react");exports.Fragment=60107;if("function"===typeof Symbol&&Symbol.for){var a=Symbol.for;exports.Fragment=a("react.fragment")}var jsxRuntime=require('./react-jsx-runtime.production.min.js');exports.jsxDEV=function(type,props,key,isStaticChildren){return (isStaticChildren?jsxRuntime.jsxs:jsxRuntime.jsx)(type,props,key);};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,16 +4,21 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  react@17.0.2:
+    hash: fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676
+    path: patches/react@17.0.2.patch
+
 importers:
 
   .:
     dependencies:
       '@callstack/react-theme-provider':
         specifier: ^3.0.7
-        version: 3.0.7(react@17.0.2)
+        version: 3.0.7(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@docsearch/react':
         specifier: '3'
-        version: 3.0.0(@algolia/client-search@4.13.0)(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 3.0.0(@algolia/client-search@4.13.0)(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       glob:
         specifier: ^8.0.1
         version: 8.0.1
@@ -28,19 +33,19 @@ importers:
         version: 2.3.1(@babel/core@7.17.5)
       next:
         specifier: 12.3.4
-        version: 12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       next-linaria:
         specifier: ^0.11.0
         version: 0.11.0(linaria@2.3.1(@babel/core@7.17.5))
       next-mdx-remote:
         specifier: ^4.0.2
-        version: 4.0.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 4.0.2(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       react:
         specifier: 17.0.2
-        version: 17.0.2
+        version: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
       react-dom:
         specifier: 17.0.2
-        version: 17.0.2(react@17.0.2)
+        version: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       react-responsive-carousel:
         specifier: ^3.2.23
         version: 3.2.23
@@ -80,25 +85,25 @@ importers:
         version: 12.1.5
       '@react-theming/storybook-addon':
         specifier: ^1.1.5
-        version: 1.1.5(@storybook/addons@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(@storybook/theming@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 1.1.5(365410515a6382f8d0aa569e6ce531d2)
       '@storybook/addon-actions':
         specifier: ^6.4.19
-        version: 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/addon-essentials':
         specifier: ^6.4.19
-        version: 6.4.19(@babel/core@7.17.5)(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(@types/react@17.0.39)(babel-loader@8.2.3(@babel/core@7.17.5)(webpack@4.46.0))(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)(webpack@4.46.0)
+        version: 6.4.19(@babel/core@7.17.5)(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(@types/react@17.0.39)(babel-loader@8.2.3(@babel/core@7.17.5)(webpack@4.46.0))(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)(webpack@4.46.0)
       '@storybook/addon-interactions':
         specifier: ^6.4.19
-        version: 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
+        version: 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
       '@storybook/addon-links':
         specifier: ^6.4.19
-        version: 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/react':
         specifier: ^6.4.19
-        version: 6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1)
+        version: 6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1)
       '@storybook/testing-library':
         specifier: ^0.0.9
-        version: 0.0.9(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 0.0.9(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@types/glob':
         specifier: ^8.1.0
         version: 8.1.0
@@ -140,7 +145,7 @@ importers:
         version: 16.1.4(@typescript-eslint/eslint-plugin@5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.10.0)(typescript@4.5.5))(eslint@8.10.0)(typescript@4.5.5))(@typescript-eslint/parser@5.61.0(eslint@8.10.0)(typescript@4.5.5))(eslint-plugin-import@2.25.4)(eslint@8.10.0)
       eslint-config-next:
         specifier: 12.1.0
-        version: 12.1.0(eslint@8.10.0)(next@12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(typescript@4.5.5)
+        version: 12.1.0(eslint@8.10.0)(next@12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(typescript@4.5.5)
       eslint-config-prettier:
         specifier: ^8.5.0
         version: 8.5.0(eslint@8.10.0)
@@ -167,7 +172,7 @@ importers:
         version: 1.0.0
       next-sitemap:
         specifier: ^2.5.20
-        version: 2.5.20(next@12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
+        version: 2.5.20(next@12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))
       prettier:
         specifier: 2.4.1
         version: 2.4.1
@@ -1168,9 +1173,11 @@ packages:
   '@humanwhocodes/config-array@0.9.5':
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/object-schema@1.2.1':
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@icons/material@0.2.4':
     resolution: {integrity: sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==}
@@ -1291,24 +1298,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@12.3.4':
     resolution: {integrity: sha512-EETZPa1juczrKLWk5okoW2hv7D7WvonU+Cf2CgsSoxgsYbUCZ1voOpL4JZTOb6IbKMDo6ja+SbY0vzXZBUMvkQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@12.3.4':
     resolution: {integrity: sha512-4csPbRbfZbuWOk3ATyWcvVFdD9/Rsdq5YHKvRuEni68OCLkfy4f+4I9OBpyK1SKJ00Cih16NJbHE+k+ljPPpag==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@12.3.4':
     resolution: {integrity: sha512-YeBmI+63Ro75SUiL/QXEVXQ19T++58aI/IINOyhpsRL1LKdyfK/35iilraZEFz9bLQrwy1LYAR5lK200A9Gjbg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@12.3.4':
     resolution: {integrity: sha512-Sd0qFUJv8Tj0PukAYbCCDbmXcMkbIuhnTeHm9m4ZGjCf6kt7E/RMs55Pd3R5ePjOkN7dJEuxYBehawTR/aPDSQ==}
@@ -1440,6 +1451,7 @@ packages:
 
   '@storybook/addon-actions@6.4.19':
     resolution: {integrity: sha512-GpSvP8xV8GfNkmtGJjfCgaOx6mbjtyTK0aT9FqX9pU0s+KVMmoCTrBh43b7dWrwxxas01yleBK9VpYggzhi/Fw==}
+    deprecated: 'SECURITY: Upgrade to v6.5 or above'
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -1625,6 +1637,7 @@ packages:
 
   '@storybook/api@6.4.19':
     resolution: {integrity: sha512-aDvea+NpQCBjpNp9YidO1Pr7fzzCp15FSdkG+2ihGQfv5raxrN+IIJnGUXecpe71nvlYiB+29UXBVK7AL0j51Q==}
+    deprecated: 'SECURITY: Upgrade to v6.5 or above'
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -1676,6 +1689,7 @@ packages:
 
   '@storybook/core-common@6.4.19':
     resolution: {integrity: sha512-X1pJJkO48DFxl6iyEemIKqRkJ7j9/cBh3BRBUr+xZHXBvnD0GKDXIocwh0PjSxSC6XSu3UCQnqtKi3PbjRl8Dg==}
+    deprecated: 'SECURITY: Upgrade to v6.5 or above'
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -1689,6 +1703,7 @@ packages:
 
   '@storybook/core-server@6.4.19':
     resolution: {integrity: sha512-bKsUB9f7hl5ya2JXxpIrErmbDQjoH39FVbzYZWjMo4t/b7+Xyi6vYadwyWcqlpUQmis09ZaSMv8L/Tw0TuwLAA==}
+    deprecated: 'SECURITY: Upgrade to v6.5 or above'
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.19
       '@storybook/manager-webpack5': 6.4.19
@@ -1731,6 +1746,7 @@ packages:
 
   '@storybook/manager-webpack4@6.4.19':
     resolution: {integrity: sha512-R8ugZjTYqXvlc6gDOcw909L65sIleOmIJLZR+N6/H85MivGXHu39jOwONqB7tVACufRty4FNecn8tEiQL2SAKA==}
+    deprecated: 'SECURITY: Upgrade to v6 or above'
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -2160,6 +2176,7 @@ packages:
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -2291,6 +2308,7 @@ packages:
   are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -2516,6 +2534,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   batch-processor@1.0.0:
     resolution: {integrity: sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==}
@@ -2949,6 +2968,7 @@ packages:
 
   copy-concurrently@1.0.5:
     resolution: {integrity: sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==}
+    deprecated: This package is no longer supported.
 
   copy-descriptor@0.1.1:
     resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==}
@@ -3242,6 +3262,7 @@ packages:
   domexception@2.0.1:
     resolution: {integrity: sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==}
     engines: {node: '>=8'}
+    deprecated: Use your platform's native DOMException instead
 
   domhandler@4.3.0:
     resolution: {integrity: sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==}
@@ -3549,6 +3570,7 @@ packages:
   eslint@8.10.0:
     resolution: {integrity: sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.3.1:
@@ -3686,6 +3708,7 @@ packages:
 
   figgy-pudding@3.5.2:
     resolution: {integrity: sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==}
+    deprecated: This module is no longer supported.
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -3839,6 +3862,7 @@ packages:
 
   fs-write-stream-atomic@1.0.10:
     resolution: {integrity: sha512-gehEzmPn2nAwr39eay+x3X34Ra+M2QlVUTLhkXPjWdeO8RF9kszk116avgBJM3ZyNHgHXBNx+VmPaFC36k0PzA==}
+    deprecated: This package is no longer supported.
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -3879,6 +3903,7 @@ packages:
   gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -3942,13 +3967,16 @@ packages:
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.0.1:
     resolution: {integrity: sha512-cF7FYZZ47YzmCu7dDy50xSRRfO3ErRfrXuLZcNIuyiJEco0XSrGtuilG19L5xp3NcwTx7Gn+X6Tv3fmsUPTbow==}
     engines: {node: '>=12'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global@4.4.0:
     resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
@@ -4217,6 +4245,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.1:
     resolution: {integrity: sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==}
@@ -4263,10 +4292,12 @@ packages:
   is-accessor-descriptor@0.1.6:
     resolution: {integrity: sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v0.1.7
 
   is-accessor-descriptor@1.0.0:
     resolution: {integrity: sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v1.0.1
 
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -4333,10 +4364,12 @@ packages:
   is-data-descriptor@0.1.4:
     resolution: {integrity: sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v0.1.5
 
   is-data-descriptor@1.0.0:
     resolution: {integrity: sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==}
     engines: {node: '>=0.10.0'}
+    deprecated: Please upgrade to v1.0.1
 
   is-date-object@1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
@@ -5162,6 +5195,7 @@ packages:
 
   move-concurrently@1.0.1:
     resolution: {integrity: sha512-hdrFxZOycD/g6A6SoI2bB5NA/5NEqD0569+S47WZhPvm46sD50ZHdYaFmnua5lndde9rCHGjmfK7Z8BuCt/PcQ==}
+    deprecated: This package is no longer supported.
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -5325,6 +5359,7 @@ packages:
 
   npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
 
   nth-check@2.0.1:
     resolution: {integrity: sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==}
@@ -6187,10 +6222,12 @@ packages:
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   ripemd160@2.0.2:
@@ -6612,9 +6649,11 @@ packages:
   tar@6.1.11:
     resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
     engines: {node: '>= 10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   telejson@5.3.3:
     resolution: {integrity: sha512-PjqkJZpzEggA9TBpVtJi1LVptP7tYtXB6rEubwlHap76AMjzvOdKX41CxyaW7ahhzDU1aftXnMCx5kAPDZTQBA==}
+    deprecated: 'SECURITY: Upgrade to v6 or above'
 
   terser-webpack-plugin@1.4.5:
     resolution: {integrity: sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==}
@@ -7017,7 +7056,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.3:
@@ -7147,10 +7186,12 @@ packages:
 
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
@@ -8277,11 +8318,11 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@callstack/react-theme-provider@3.0.7(react@17.0.2)':
+  '@callstack/react-theme-provider@3.0.7(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       deepmerge: 3.3.0
       hoist-non-react-statics: 3.3.2
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   '@cnakazawa/watch@1.0.4':
     dependencies:
@@ -8294,15 +8335,15 @@ snapshots:
 
   '@docsearch/css@3.0.0': {}
 
-  '@docsearch/react@3.0.0(@algolia/client-search@4.13.0)(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@docsearch/react@3.0.0(@algolia/client-search@4.13.0)(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       '@algolia/autocomplete-core': 1.5.2
       '@algolia/autocomplete-preset-algolia': 1.5.2(@algolia/client-search@4.13.0)(algoliasearch@4.13.0)
       '@docsearch/css': 3.0.0
       '@types/react': 17.0.39
       algoliasearch: 4.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - '@algolia/client-search'
 
@@ -8313,7 +8354,7 @@ snapshots:
       '@emotion/utils': 0.11.3
       '@emotion/weak-memoize': 0.2.5
 
-  '@emotion/core@10.3.1(react@17.0.2)':
+  '@emotion/core@10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       '@babel/runtime': 7.17.2
       '@emotion/cache': 10.0.29
@@ -8321,7 +8362,7 @@ snapshots:
       '@emotion/serialize': 0.11.16
       '@emotion/sheet': 0.9.4
       '@emotion/utils': 0.11.3
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   '@emotion/css@10.0.27':
     dependencies:
@@ -8347,21 +8388,21 @@ snapshots:
 
   '@emotion/sheet@0.9.4': {}
 
-  '@emotion/styled-base@10.3.0(@emotion/core@10.3.1(react@17.0.2))(react@17.0.2)':
+  '@emotion/styled-base@10.3.0(@emotion/core@10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       '@babel/runtime': 7.17.2
-      '@emotion/core': 10.3.1(react@17.0.2)
+      '@emotion/core': 10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@emotion/is-prop-valid': 0.8.8
       '@emotion/serialize': 0.11.16
       '@emotion/utils': 0.11.3
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
-  '@emotion/styled@10.3.0(@emotion/core@10.3.1(react@17.0.2))(react@17.0.2)':
+  '@emotion/styled@10.3.0(@emotion/core@10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@emotion/core': 10.3.1(react@17.0.2)
-      '@emotion/styled-base': 10.3.0(@emotion/core@10.3.1(react@17.0.2))(react@17.0.2)
+      '@emotion/core': 10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@emotion/styled-base': 10.3.0(@emotion/core@10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       babel-plugin-emotion: 10.2.2
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   '@emotion/stylis@0.8.5': {}
 
@@ -8481,9 +8522,9 @@ snapshots:
 
   '@humanwhocodes/object-schema@1.2.1': {}
 
-  '@icons/material@0.2.4(react@17.0.2)':
+  '@icons/material@0.2.4(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -8548,10 +8589,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@mdx-js/loader@1.6.22(react@17.0.2)':
+  '@mdx-js/loader@1.6.22(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       '@mdx-js/mdx': 1.6.22
-      '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@mdx-js/react': 1.6.22(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       loader-utils: 2.0.0
     transitivePeerDependencies:
       - react
@@ -8603,15 +8644,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mdx-js/react@1.6.22(react@17.0.2)':
+  '@mdx-js/react@1.6.22(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
-  '@mdx-js/react@2.1.1(react@17.0.2)':
+  '@mdx-js/react@2.1.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       '@types/mdx': 2.0.1
       '@types/react': 18.0.5
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   '@mdx-js/util@1.6.22': {}
 
@@ -8735,21 +8776,21 @@ snapshots:
 
   '@popperjs/core@2.11.2': {}
 
-  '@reach/component-component@0.1.3(prop-types@15.8.1)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@reach/component-component@0.1.3(prop-types@15.8.1)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
 
   '@reach/observe-rect@1.2.0': {}
 
-  '@reach/rect@0.2.1(prop-types@15.8.1)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@reach/rect@0.2.1(prop-types@15.8.1)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@reach/component-component': 0.1.3(prop-types@15.8.1)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@reach/component-component': 0.1.3(prop-types@15.8.1)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@reach/observe-rect': 1.2.0
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
 
   '@react-theming/flatten@0.1.1':
     dependencies:
@@ -8763,17 +8804,17 @@ snapshots:
       is-color-stop: 1.1.0
       rgb-hex: 3.0.0
 
-  '@react-theming/storybook-addon@1.1.5(@storybook/addons@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(@storybook/theming@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@react-theming/storybook-addon@1.1.5(365410515a6382f8d0aa569e6ce531d2)':
     dependencies:
       '@react-theming/flatten': 0.1.1
       '@react-theming/theme-name': 1.0.3
-      '@react-theming/theme-swatch': 1.0.0(react@17.0.2)
-      '@storybook/addon-devkit': 1.4.2(@storybook/addons@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/react': 6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1)
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@usulpro/react-json-view': 2.0.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      react: 17.0.2
-      react-color: 2.19.3(react@17.0.2)
+      '@react-theming/theme-swatch': 1.0.0(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/addon-devkit': 1.4.2(@storybook/addons@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/react': 6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1)
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@usulpro/react-json-view': 2.0.1(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-color: 2.19.3(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - '@storybook/addons'
       - encoding
@@ -8784,47 +8825,47 @@ snapshots:
       color-name-list: 4.15.0
       nearest-color: 0.4.4
 
-  '@react-theming/theme-swatch@1.0.0(react@17.0.2)':
+  '@react-theming/theme-swatch@1.0.0(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   '@rushstack/eslint-patch@1.1.0': {}
 
-  '@storybook/addon-actions@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addon-actions@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       core-js: 3.21.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
       lodash: 4.17.21
       polished: 4.1.4
       prop-types: 15.8.1
-      react-inspector: 5.1.1(react@17.0.2)
+      react-inspector: 5.1.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       regenerator-runtime: 0.13.9
       telejson: 5.3.3
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
       uuid-browser: 3.1.0
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-backgrounds@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addon-backgrounds@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
-      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       core-js: 3.21.1
       global: 4.4.0
       memoizerific: 1.11.3
@@ -8832,28 +8873,28 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-controls@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)':
+  '@storybook/addon-controls@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
-      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
+      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/node-logger': 6.4.19
-      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       core-js: 3.21.1
       lodash: 4.17.21
       ts-dedent: 2.2.0
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - '@types/react'
       - eslint
@@ -8863,19 +8904,19 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/addon-devkit@1.4.2(@storybook/addons@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addon-devkit@1.4.2(@storybook/addons@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@reach/rect': 0.2.1(prop-types@15.8.1)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@reach/rect': 0.2.1(prop-types@15.8.1)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/core-events': 6.4.19
-      '@storybook/react': 6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1)
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/react': 6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1)
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       deep-equal: 2.0.5
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
 
-  '@storybook/addon-docs@6.4.19(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)(webpack@4.46.0)':
+  '@storybook/addon-docs@6.4.19(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)(webpack@4.46.0)':
     dependencies:
       '@babel/core': 7.17.5
       '@babel/generator': 7.23.0
@@ -8883,24 +8924,24 @@ snapshots:
       '@babel/plugin-transform-react-jsx': 7.17.3(@babel/core@7.17.5)
       '@babel/preset-env': 7.16.11(@babel/core@7.17.5)
       '@jest/transform': 26.6.2
-      '@mdx-js/loader': 1.6.22(react@17.0.2)
+      '@mdx-js/loader': 1.6.22(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@mdx-js/mdx': 1.6.22
-      '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/builder-webpack4': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
+      '@mdx-js/react': 1.6.22(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/builder-webpack4': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
       '@storybook/client-logger': 6.4.19
-      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)(webpack@4.46.0)
+      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/core': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)(webpack@4.46.0)
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.19
       '@storybook/node-logger': 6.4.19
       '@storybook/postinstall': 6.4.19
-      '@storybook/preview-web': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/source-loader': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/preview-web': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/source-loader': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       acorn: 7.4.1
       acorn-jsx: 5.3.2(acorn@7.4.1)
       acorn-walk: 7.2.0
@@ -8917,16 +8958,16 @@ snapshots:
       p-limit: 3.1.0
       prettier: 2.3.0
       prop-types: 15.8.1
-      react-element-to-jsx-string: 14.3.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react-element-to-jsx-string: 14.3.4(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       regenerator-runtime: 0.13.9
       remark-external-links: 8.0.0
       remark-slug: 6.1.0
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
     optionalDependencies:
-      '@storybook/react': 6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      '@storybook/react': 6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       webpack: 4.46.0
     transitivePeerDependencies:
       - '@storybook/builder-webpack5'
@@ -8943,27 +8984,27 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/addon-essentials@6.4.19(@babel/core@7.17.5)(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(@types/react@17.0.39)(babel-loader@8.2.3(@babel/core@7.17.5)(webpack@4.46.0))(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)(webpack@4.46.0)':
+  '@storybook/addon-essentials@6.4.19(@babel/core@7.17.5)(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(@types/react@17.0.39)(babel-loader@8.2.3(@babel/core@7.17.5)(webpack@4.46.0))(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)(webpack@4.46.0)':
     dependencies:
       '@babel/core': 7.17.5
-      '@storybook/addon-actions': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/addon-backgrounds': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/addon-controls': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
-      '@storybook/addon-docs': 6.4.19(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)(webpack@4.46.0)
-      '@storybook/addon-measure': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/addon-outline': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/addon-toolbars': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/addon-viewport': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addon-actions': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/addon-backgrounds': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/addon-controls': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
+      '@storybook/addon-docs': 6.4.19(@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1))(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)(webpack@4.46.0)
+      '@storybook/addon-measure': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/addon-outline': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/addon-toolbars': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/addon-viewport': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/node-logger': 6.4.19
       babel-loader: 8.2.3(@babel/core@7.17.5)(webpack@4.46.0)
       core-js: 3.21.1
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       webpack: 4.46.0
     transitivePeerDependencies:
       - '@storybook/angular'
@@ -8988,23 +9029,23 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/addon-interactions@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)':
+  '@storybook/addon-interactions@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/instrumenter': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/instrumenter': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       global: 4.4.0
       jest-mock: 27.5.1
       polished: 4.1.4
       ts-dedent: 2.2.0
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - '@types/react'
       - eslint
@@ -9014,13 +9055,13 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/addon-links@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addon-links@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/router': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/router': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@types/qs': 6.9.7
       core-js: 3.21.1
       global: 4.4.0
@@ -9029,31 +9070,31 @@ snapshots:
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
 
-  '@storybook/addon-measure@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addon-measure@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
-      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
       core-js: 3.21.1
       global: 4.4.0
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-outline@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addon-outline@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
-      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
       core-js: 3.21.1
@@ -9061,83 +9102,83 @@ snapshots:
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-toolbars@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addon-toolbars@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       core-js: 3.21.1
       regenerator-runtime: 0.13.9
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-viewport@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addon-viewport@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
-      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/core-events': 6.4.19
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       core-js: 3.21.1
       global: 4.4.0
       memoizerific: 1.11.3
       prop-types: 15.8.1
       regenerator-runtime: 0.13.9
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addons@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/addons@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/channels': 6.4.19
       '@storybook/client-logger': 6.4.19
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/router': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/router': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@types/webpack-env': 1.16.3
       core-js: 3.21.1
       global: 4.4.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       regenerator-runtime: 0.13.9
 
-  '@storybook/api@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/api@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       '@storybook/channels': 6.4.19
       '@storybook/client-logger': 6.4.19
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/router': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/router': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       core-js: 3.21.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
       lodash: 4.17.21
       memoizerific: 1.11.3
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       regenerator-runtime: 0.13.9
       store2: 2.13.1
       telejson: 5.3.3
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  '@storybook/builder-webpack4@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)':
+  '@storybook/builder-webpack4@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)':
     dependencies:
       '@babel/core': 7.17.5
       '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.17.5)
@@ -9160,22 +9201,22 @@ snapshots:
       '@babel/preset-env': 7.16.11(@babel/core@7.17.5)
       '@babel/preset-react': 7.16.7(@babel/core@7.17.5)
       '@babel/preset-typescript': 7.16.7(@babel/core@7.17.5)
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/channel-postmessage': 6.4.19
       '@storybook/channels': 6.4.19
-      '@storybook/client-api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/client-api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
-      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
+      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
       '@storybook/core-events': 6.4.19
       '@storybook/node-logger': 6.4.19
-      '@storybook/preview-web': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/router': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/preview-web': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/router': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/ui': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/ui': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@types/node': 14.18.12
       '@types/webpack': 4.41.32
       autoprefixer: 9.8.8
@@ -9197,8 +9238,8 @@ snapshots:
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0(postcss@7.0.39)(webpack@4.46.0)
       raw-loader: 4.0.2(webpack@4.46.0)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       stable: 0.1.8
       style-loader: 1.3.0(webpack@4.46.0)
       terser-webpack-plugin: 4.2.3(webpack@4.46.0)
@@ -9245,15 +9286,15 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  '@storybook/client-api@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/client-api@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/channel-postmessage': 6.4.19
       '@storybook/channels': 6.4.19
       '@storybook/client-logger': 6.4.19
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@types/qs': 6.9.7
       '@types/webpack-env': 1.16.3
       core-js: 3.21.1
@@ -9262,8 +9303,8 @@ snapshots:
       lodash: 4.17.21
       memoizerific: 1.11.3
       qs: 6.10.3
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       regenerator-runtime: 0.13.9
       store2: 2.13.1
       synchronous-promise: 2.0.15
@@ -9275,12 +9316,12 @@ snapshots:
       core-js: 3.21.1
       global: 4.4.0
 
-  '@storybook/components@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/components@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       '@popperjs/core': 2.11.2
       '@storybook/client-logger': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@types/color-convert': 2.0.0
       '@types/overlayscrollbars': 1.12.1
       '@types/react-syntax-highlighter': 11.0.5
@@ -9289,43 +9330,43 @@ snapshots:
       fast-deep-equal: 3.1.3
       global: 4.4.0
       lodash: 4.17.21
-      markdown-to-jsx: 7.1.6(react@17.0.2)
+      markdown-to-jsx: 7.1.6(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       memoizerific: 1.11.3
       overlayscrollbars: 1.13.1
       polished: 4.1.4
       prop-types: 15.8.1
-      react: 17.0.2
-      react-colorful: 5.5.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      react-dom: 17.0.2(react@17.0.2)
-      react-popper-tooltip: 3.1.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      react-syntax-highlighter: 13.5.3(react@17.0.2)
-      react-textarea-autosize: 8.3.3(@types/react@17.0.39)(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-colorful: 5.5.1(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react-popper-tooltip: 3.1.1(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react-syntax-highlighter: 13.5.3(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react-textarea-autosize: 8.3.3(@types/react@17.0.39)(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/core-client@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)(webpack@4.46.0)':
+  '@storybook/core-client@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)(webpack@4.46.0)':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/channel-postmessage': 6.4.19
       '@storybook/channel-websocket': 6.4.19
-      '@storybook/client-api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/client-api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/preview-web': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/ui': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/preview-web': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/ui': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       airbnb-js-shims: 2.2.1
       ansi-to-html: 0.6.15
       core-js: 3.21.1
       global: 4.4.0
       lodash: 4.17.21
       qs: 6.10.3
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
       unfetch: 4.2.0
@@ -9336,7 +9377,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/core-common@6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)':
+  '@storybook/core-common@6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)':
     dependencies:
       '@babel/core': 7.17.5
       '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.17.5)
@@ -9381,8 +9422,8 @@ snapshots:
       picomatch: 2.3.1
       pkg-dir: 5.0.0
       pretty-hrtime: 1.0.3
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       resolve-from: 5.0.0
       slash: 3.0.0
       telejson: 5.3.3
@@ -9402,19 +9443,19 @@ snapshots:
     dependencies:
       core-js: 3.21.1
 
-  '@storybook/core-server@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)':
+  '@storybook/core-server@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)':
     dependencies:
       '@discoveryjs/json-ext': 0.5.6
-      '@storybook/builder-webpack4': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
-      '@storybook/core-client': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)(webpack@4.46.0)
-      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
+      '@storybook/builder-webpack4': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
+      '@storybook/core-client': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)(webpack@4.46.0)
+      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.19
-      '@storybook/manager-webpack4': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
+      '@storybook/manager-webpack4': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
       '@storybook/node-logger': 6.4.19
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@types/node': 14.18.12
       '@types/node-fetch': 2.6.1
       '@types/pretty-hrtime': 1.0.1
@@ -9437,8 +9478,8 @@ snapshots:
       node-fetch: 2.6.7
       pretty-hrtime: 1.0.3
       prompts: 2.4.2
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       regenerator-runtime: 0.13.9
       serve-favicon: 2.5.0
       slash: 3.0.0
@@ -9462,12 +9503,12 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@storybook/core@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)(webpack@4.46.0)':
+  '@storybook/core@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)(webpack@4.46.0)':
     dependencies:
-      '@storybook/core-client': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)(webpack@4.46.0)
-      '@storybook/core-server': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      '@storybook/core-client': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)(webpack@4.46.0)
+      '@storybook/core-server': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       webpack: 4.46.0
     optionalDependencies:
       typescript: 4.5.5
@@ -9514,9 +9555,9 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
-  '@storybook/instrumenter@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/instrumenter@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
       '@storybook/core-events': 6.4.19
       global: 4.4.0
@@ -9524,17 +9565,17 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/manager-webpack4@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)':
+  '@storybook/manager-webpack4@6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)':
     dependencies:
       '@babel/core': 7.17.5
       '@babel/plugin-transform-template-literals': 7.16.7(@babel/core@7.17.5)
       '@babel/preset-react': 7.16.7(@babel/core@7.17.5)
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core-client': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)(webpack@4.46.0)
-      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/core-client': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)(webpack@4.46.0)
+      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
       '@storybook/node-logger': 6.4.19
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/ui': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/ui': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@types/node': 14.18.12
       '@types/webpack': 4.41.32
       babel-loader: 8.2.3(@babel/core@7.17.5)(webpack@4.46.0)
@@ -9550,8 +9591,8 @@ snapshots:
       html-webpack-plugin: 4.5.2(webpack@4.46.0)
       node-fetch: 2.6.7
       pnp-webpack-plugin: 1.6.4(typescript@4.5.5)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.9
       resolve-from: 5.0.0
@@ -9588,21 +9629,21 @@ snapshots:
     dependencies:
       core-js: 3.21.1
 
-  '@storybook/preview-web@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/preview-web@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/channel-postmessage': 6.4.19
       '@storybook/client-logger': 6.4.19
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       ansi-to-html: 0.6.15
       core-js: 3.21.1
       global: 4.4.0
       lodash: 4.17.21
       qs: 6.10.3
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       regenerator-runtime: 0.13.9
       synchronous-promise: 2.0.15
       ts-dedent: 2.2.0
@@ -9623,19 +9664,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1)':
+  '@storybook/react@6.4.19(@babel/core@7.17.5)(@types/react@17.0.39)(@types/webpack@4.41.32)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(type-fest@0.20.2)(typescript@4.5.5)(webpack-hot-middleware@2.25.1)':
     dependencies:
       '@babel/preset-flow': 7.16.7(@babel/core@7.17.5)
       '@babel/preset-react': 7.16.7(@babel/core@7.17.5)
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@4.41.32)(react-refresh@0.11.0)(type-fest@0.20.2)(webpack-hot-middleware@2.25.1)(webpack@4.46.0)
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/core': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)(webpack@4.46.0)
-      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.5.5)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/core': 6.4.19(@types/react@17.0.39)(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)(webpack@4.46.0)
+      '@storybook/core-common': 6.4.19(eslint@8.10.0)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))(typescript@4.5.5)
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/node-logger': 6.4.19
       '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.253f8c1.0(typescript@4.5.5)(webpack@4.46.0)
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/store': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@types/webpack-env': 1.16.3
       babel-plugin-add-react-displayname: 0.0.5
       babel-plugin-named-asset-import: 0.3.8(@babel/core@7.17.5)
@@ -9644,8 +9685,8 @@ snapshots:
       global: 4.4.0
       lodash: 4.17.21
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       react-refresh: 0.11.0
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.9
@@ -9674,7 +9715,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/router@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/router@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       '@storybook/client-logger': 6.4.19
       core-js: 3.21.1
@@ -9684,10 +9725,10 @@ snapshots:
       lodash: 4.17.21
       memoizerific: 1.11.3
       qs: 6.10.3
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-router: 6.2.2(react@17.0.2)
-      react-router-dom: 6.2.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react-router: 6.2.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react-router-dom: 6.2.2(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       ts-dedent: 2.2.0
 
   '@storybook/semver@7.3.2':
@@ -9695,9 +9736,9 @@ snapshots:
       core-js: 3.21.1
       find-up: 4.1.0
 
-  '@storybook/source-loader@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/source-loader@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
       core-js: 3.21.1
@@ -9706,13 +9747,13 @@ snapshots:
       loader-utils: 2.0.2
       lodash: 4.17.21
       prettier: 2.3.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       regenerator-runtime: 0.13.9
 
-  '@storybook/store@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/store@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
@@ -9721,8 +9762,8 @@ snapshots:
       global: 4.4.0
       lodash: 4.17.21
       memoizerific: 1.11.3
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       regenerator-runtime: 0.13.9
       slash: 3.0.0
       stable: 0.1.8
@@ -9730,10 +9771,10 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  '@storybook/testing-library@0.0.9(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/testing-library@0.0.9(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       '@storybook/client-logger': 6.4.19
-      '@storybook/instrumenter': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/instrumenter': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@testing-library/dom': 8.11.3
       '@testing-library/user-event': 13.5.0(@testing-library/dom@8.11.3)
       ts-dedent: 2.2.0
@@ -9741,51 +9782,51 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/theming@6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/theming@6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@emotion/core': 10.3.1(react@17.0.2)
+      '@emotion/core': 10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@emotion/is-prop-valid': 0.8.8
-      '@emotion/styled': 10.3.0(@emotion/core@10.3.1(react@17.0.2))(react@17.0.2)
+      '@emotion/styled': 10.3.0(@emotion/core@10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/client-logger': 6.4.19
       core-js: 3.21.1
       deep-object-diff: 1.1.9
-      emotion-theming: 10.3.0(@emotion/core@10.3.1(react@17.0.2))(react@17.0.2)
+      emotion-theming: 10.3.0(@emotion/core@10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       global: 4.4.0
       memoizerific: 1.11.3
       polished: 4.1.4
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       resolve-from: 5.0.0
       ts-dedent: 2.2.0
 
-  '@storybook/ui@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@storybook/ui@6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
-      '@emotion/core': 10.3.1(react@17.0.2)
-      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@emotion/core': 10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/addons': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      '@storybook/api': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/channels': 6.4.19
       '@storybook/client-logger': 6.4.19
-      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/components': 6.4.19(@types/react@17.0.39)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/core-events': 6.4.19
-      '@storybook/router': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/router': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@storybook/theming': 6.4.19(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       copy-to-clipboard: 3.3.1
       core-js: 3.21.1
       core-js-pure: 3.21.1
-      downshift: 6.1.7(react@17.0.2)
-      emotion-theming: 10.3.0(@emotion/core@10.3.1(react@17.0.2))(react@17.0.2)
+      downshift: 6.1.7(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      emotion-theming: 10.3.0(@emotion/core@10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       fuse.js: 3.6.1
       global: 4.4.0
       lodash: 4.17.21
-      markdown-to-jsx: 7.1.6(react@17.0.2)
+      markdown-to-jsx: 7.1.6(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       memoizerific: 1.11.3
       polished: 4.1.4
       qs: 6.10.3
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-draggable: 4.4.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      react-helmet-async: 1.2.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react-draggable: 4.4.4(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react-helmet-async: 1.2.3(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       react-sizeme: 3.0.2
       regenerator-runtime: 0.13.9
       resolve-from: 5.0.0
@@ -10121,15 +10162,15 @@ snapshots:
       '@typescript-eslint/types': 5.61.0
       eslint-visitor-keys: 3.3.0
 
-  '@usulpro/react-json-view@2.0.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@usulpro/react-json-view@2.0.1(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))':
     dependencies:
       color-string: 1.9.0
-      flux: 4.0.3(react@17.0.2)
-      react: 17.0.2
+      flux: 4.0.3(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
       react-base16-styling: 0.6.0
-      react-dom: 17.0.2(react@17.0.2)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       react-lifecycles-compat: 3.0.4
-      react-textarea-autosize: 6.1.0(react@17.0.2)
+      react-textarea-autosize: 6.1.0(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - encoding
 
@@ -11562,12 +11603,12 @@ snapshots:
 
   dotenv@8.6.0: {}
 
-  downshift@6.1.7(react@17.0.2):
+  downshift@6.1.7(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       '@babel/runtime': 7.17.2
       compute-scroll-into-view: 1.0.17
       prop-types: 15.8.1
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
       react-is: 17.0.2
       tslib: 2.3.1
 
@@ -11606,13 +11647,13 @@ snapshots:
 
   emojis-list@3.0.0: {}
 
-  emotion-theming@10.3.0(@emotion/core@10.3.1(react@17.0.2))(react@17.0.2):
+  emotion-theming@10.3.0(@emotion/core@10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       '@babel/runtime': 7.17.2
-      '@emotion/core': 10.3.1(react@17.0.2)
+      '@emotion/core': 10.3.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       '@emotion/weak-memoize': 0.2.5
       hoist-non-react-statics: 3.3.2
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   encodeurl@1.0.2: {}
 
@@ -11784,7 +11825,7 @@ snapshots:
       object.assign: 4.1.2
       object.entries: 1.1.5
 
-  eslint-config-next@12.1.0(eslint@8.10.0)(next@12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(typescript@4.5.5):
+  eslint-config-next@12.1.0(eslint@8.10.0)(next@12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(typescript@4.5.5):
     dependencies:
       '@next/eslint-plugin-next': 12.1.0
       '@rushstack/eslint-patch': 1.1.0
@@ -11796,7 +11837,7 @@ snapshots:
       eslint-plugin-jsx-a11y: 6.5.1(eslint@8.10.0)
       eslint-plugin-react: 7.29.2(eslint@8.10.0)
       eslint-plugin-react-hooks: 4.3.0(eslint@8.10.0)
-      next: 12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      next: 12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     optionalDependencies:
       typescript: 4.5.5
     transitivePeerDependencies:
@@ -12276,11 +12317,11 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.7
 
-  flux@4.0.3(react@17.0.2):
+  flux@4.0.3(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       fbemitter: 3.0.0
       fbjs: 3.0.4
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
     transitivePeerDependencies:
       - encoding
 
@@ -13527,9 +13568,9 @@ snapshots:
 
   markdown-table@3.0.2: {}
 
-  markdown-to-jsx@7.1.6(react@17.0.2):
+  markdown-to-jsx@7.1.6(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   marked@12.0.2: {}
 
@@ -14190,12 +14231,12 @@ snapshots:
     dependencies:
       linaria: 2.3.1(@babel/core@7.17.5)
 
-  next-mdx-remote@4.0.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  next-mdx-remote@4.0.2(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       '@mdx-js/mdx': 2.1.0
-      '@mdx-js/react': 2.1.1(react@17.0.2)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      '@mdx-js/react': 2.1.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       vfile: 5.3.2
       vfile-matter: 3.0.1
     transitivePeerDependencies:
@@ -14211,22 +14252,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  next-sitemap@2.5.20(next@12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)):
+  next-sitemap@2.5.20(next@12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))):
     dependencies:
       '@corex/deepmerge': 2.6.148
       minimist: 1.2.7
-      next: 12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      next: 12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
 
-  next@12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  next@12.3.4(@babel/core@7.17.5)(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       '@next/env': 12.3.4
       '@swc/helpers': 0.4.11
       caniuse-lite: 1.0.30001561
       postcss: 8.4.14
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      styled-jsx: 5.0.7(@babel/core@7.17.5)(react@17.0.2)
-      use-sync-external-store: 1.2.0(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      styled-jsx: 5.0.7(@babel/core@7.17.5)(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      use-sync-external-store: 1.2.0(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     optionalDependencies:
       '@next/swc-android-arm-eabi': 12.3.4
       '@next/swc-android-arm64': 12.3.4
@@ -14912,21 +14953,21 @@ snapshots:
       lodash.flow: 3.5.0
       pure-color: 1.3.0
 
-  react-color@2.19.3(react@17.0.2):
+  react-color@2.19.3(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
-      '@icons/material': 0.2.4(react@17.0.2)
+      '@icons/material': 0.2.4(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       lodash: 4.17.21
       lodash-es: 4.17.21
       material-colors: 1.2.6
       prop-types: 15.8.1
-      react: 17.0.2
-      reactcss: 1.2.3(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      reactcss: 1.2.3(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       tinycolor2: 1.4.2
 
-  react-colorful@5.5.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  react-colorful@5.5.1(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
 
   react-docgen-typescript@2.2.2(typescript@4.5.5):
     dependencies:
@@ -14947,50 +14988,50 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-dom@17.0.2(react@17.0.2):
+  react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
       scheduler: 0.20.2
 
-  react-draggable@4.4.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  react-draggable@4.4.4(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       clsx: 1.1.1
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
 
   react-easy-swipe@0.0.21:
     dependencies:
       prop-types: 15.8.1
 
-  react-element-to-jsx-string@14.3.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  react-element-to-jsx-string@14.3.4(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       '@base2/pretty-print-object': 1.0.1
       is-plain-object: 5.0.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       react-is: 17.0.2
 
   react-fast-compare@3.2.0: {}
 
-  react-helmet-async@1.2.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  react-helmet-async@1.2.3(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       '@babel/runtime': 7.17.2
       invariant: 2.2.4
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
       react-fast-compare: 3.2.0
       shallowequal: 1.1.0
 
-  react-inspector@5.1.1(react@17.0.2):
+  react-inspector@5.1.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       '@babel/runtime': 7.17.2
       is-dom: 1.1.0
       prop-types: 15.8.1
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   react-is@16.13.1: {}
 
@@ -14998,18 +15039,18 @@ snapshots:
 
   react-lifecycles-compat@3.0.4: {}
 
-  react-popper-tooltip@3.1.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  react-popper-tooltip@3.1.1(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       '@babel/runtime': 7.17.2
       '@popperjs/core': 2.11.2
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-popper: 2.2.5(@popperjs/core@2.11.2)(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react-popper: 2.2.5(@popperjs/core@2.11.2)(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
 
-  react-popper@2.2.5(@popperjs/core@2.11.2)(react@17.0.2):
+  react-popper@2.2.5(@popperjs/core@2.11.2)(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       '@popperjs/core': 2.11.2
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
       react-fast-compare: 3.2.0
       warning: 4.0.3
 
@@ -15021,17 +15062,17 @@ snapshots:
       prop-types: 15.8.1
       react-easy-swipe: 0.0.21
 
-  react-router-dom@6.2.2(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  react-router-dom@6.2.2(react-dom@17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)))(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       history: 5.3.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-router: 6.2.2(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      react-dom: 17.0.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      react-router: 6.2.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
 
-  react-router@6.2.2(react@17.0.2):
+  react-router@6.2.2(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       history: 5.3.0
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   react-sizeme@3.0.2:
     dependencies:
@@ -15040,38 +15081,38 @@ snapshots:
       shallowequal: 1.1.0
       throttle-debounce: 3.0.1
 
-  react-syntax-highlighter@13.5.3(react@17.0.2):
+  react-syntax-highlighter@13.5.3(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       '@babel/runtime': 7.17.2
       highlight.js: 10.7.3
       lowlight: 1.20.0
       prismjs: 1.28.0
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
       refractor: 3.6.0
 
-  react-textarea-autosize@6.1.0(react@17.0.2):
+  react-textarea-autosize@6.1.0(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       prop-types: 15.8.1
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
-  react-textarea-autosize@8.3.3(@types/react@17.0.39)(react@17.0.2):
+  react-textarea-autosize@8.3.3(@types/react@17.0.39)(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       '@babel/runtime': 7.17.2
-      react: 17.0.2
-      use-composed-ref: 1.2.1(react@17.0.2)
-      use-latest: 1.2.0(@types/react@17.0.39)(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      use-composed-ref: 1.2.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
+      use-latest: 1.2.0(@types/react@17.0.39)(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     transitivePeerDependencies:
       - '@types/react'
 
-  react@17.0.2:
+  react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676):
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
 
-  reactcss@1.2.3(react@17.0.2):
+  reactcss@1.2.3(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
       lodash: 4.17.21
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   read-pkg-up@7.0.1:
     dependencies:
@@ -15808,9 +15849,9 @@ snapshots:
     dependencies:
       inline-style-parser: 0.1.1
 
-  styled-jsx@5.0.7(@babel/core@7.17.5)(react@17.0.2):
+  styled-jsx@5.0.7(@babel/core@7.17.5)(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
     optionalDependencies:
       '@babel/core': 7.17.5
 
@@ -16240,26 +16281,26 @@ snapshots:
       punycode: 1.3.2
       querystring: 0.2.0
 
-  use-composed-ref@1.2.1(react@17.0.2):
+  use-composed-ref@1.2.1(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
-  use-isomorphic-layout-effect@1.1.1(@types/react@17.0.39)(react@17.0.2):
+  use-isomorphic-layout-effect@1.1.1(@types/react@17.0.39)(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
     optionalDependencies:
       '@types/react': 17.0.39
 
-  use-latest@1.2.0(@types/react@17.0.39)(react@17.0.2):
+  use-latest@1.2.0(@types/react@17.0.39)(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
-      react: 17.0.2
-      use-isomorphic-layout-effect: 1.1.1(@types/react@17.0.39)(react@17.0.2)
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
+      use-isomorphic-layout-effect: 1.1.1(@types/react@17.0.39)(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676))
     optionalDependencies:
       '@types/react': 17.0.39
 
-  use-sync-external-store@1.2.0(react@17.0.2):
+  use-sync-external-store@1.2.0(react@17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)):
     dependencies:
-      react: 17.0.2
+      react: 17.0.2(patch_hash=fd543f6f0793ea12e9eeb4ee4c4858e9ca07f3e01b8a06c62c4cf56ecd98d676)
 
   use@3.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  react@17.0.2: patches/react@17.0.2.patch

--- a/src/content/docs-landing/index.md
+++ b/src/content/docs-landing/index.md
@@ -7,7 +7,7 @@ description: Documentation about Hardhat, the Ethereum development environment
 Hardhat 3 is stable and production ready, and teams are already migrating.
 Hardhat 2 will be upgraded to support the Glamsterdam hardfork and will continue
 to receive bug fixes and security fixes until its **end of life** — the earlier
-of the **Hegota mainnet activation** or the **1<sup>st</sup> of July 2027**.
+of the **Hegota mainnet activation** or the **1<sup>st</sup> of June 2027**.
 After that, there will be no further Hardhat 2 releases.
 
 **Plan your migration to Hardhat 3 now** with our [migration guide](https://hardhat.org/docs/migrate-from-hardhat2)

--- a/src/content/docs-landing/index.md
+++ b/src/content/docs-landing/index.md
@@ -3,6 +3,16 @@ title: Documentation
 description: Documentation about Hardhat, the Ethereum development environment
 ---
 
+:::tip[**Hardhat 2 is reaching end of life and is being replaced by Hardhat 3**]
+Hardhat 3 is stable and production ready, and teams are already migrating.
+Hardhat 2 will be upgraded to support the Glamsterdam hardfork and will continue
+to receive bug fixes and security fixes until its **end of life** — the earlier
+of the **Hegota mainnet activation** or the **1<sup>st</sup> of July 2027**.
+After that, there will be no further Hardhat 2 releases.
+
+**Plan your migration to Hardhat 3 now** with our [migration guide](https://hardhat.org/docs/migrate-from-hardhat2)
+:::
+
 Hardhat is a development environment for Ethereum software. It consists of different components for editing, compiling, debugging and deploying your smart contracts and dApps, all of which work together to create a complete development environment.
 
 To get started check out these sections:

--- a/src/content/hardhat-runner/docs/getting-started/index.md
+++ b/src/content/hardhat-runner/docs/getting-started/index.md
@@ -3,6 +3,16 @@ title: Getting started with Hardhat
 description: Getting started with Hardhat, a development environment to compile, deploy, test, and debug your Ethereum software
 ---
 
+:::tip[**Hardhat 2 is reaching end of life and is being replaced by Hardhat 3**]
+Hardhat 3 is stable and production ready, and teams are already migrating.
+Hardhat 2 will be upgraded to support the Glamsterdam hardfork and will continue
+to receive bug fixes and security fixes until its **end of life** — the earlier
+of the **Hegota mainnet activation** or the **1<sup>st</sup> of July 2027**.
+After that, there will be no further Hardhat 2 releases.
+
+**Start your next project with Hardhat 3** with our [getting started guide](https://hardhat.org/docs/getting-started)
+:::
+
 ## Overview
 
 Hardhat is a development environment for Ethereum software. It consists of different components for editing, compiling, debugging and deploying your smart contracts and dApps, all of which work together to create a complete development environment.

--- a/src/content/hardhat-runner/docs/getting-started/index.md
+++ b/src/content/hardhat-runner/docs/getting-started/index.md
@@ -7,7 +7,7 @@ description: Getting started with Hardhat, a development environment to compile,
 Hardhat 3 is stable and production ready, and teams are already migrating.
 Hardhat 2 will be upgraded to support the Glamsterdam hardfork and will continue
 to receive bug fixes and security fixes until its **end of life** — the earlier
-of the **Hegota mainnet activation** or the **1<sup>st</sup> of July 2027**.
+of the **Hegota mainnet activation** or the **1<sup>st</sup> of June 2027**.
 After that, there will be no further Hardhat 2 releases.
 
 **Start your next project with Hardhat 3** with our [getting started guide](https://hardhat.org/docs/getting-started)

--- a/src/content/hardhat-runner/docs/reference/_dirinfo.yaml
+++ b/src/content/hardhat-runner/docs/reference/_dirinfo.yaml
@@ -1,6 +1,7 @@
 section-type: group
 section-title: Reference
 order:
+  - /hardhat-2-end-of-life
   - /stability-guarantees
   - /solidity-support
   - /environment-variables

--- a/src/content/hardhat-runner/docs/reference/hardhat-2-end-of-life.md
+++ b/src/content/hardhat-runner/docs/reference/hardhat-2-end-of-life.md
@@ -1,0 +1,44 @@
+:::tip[**Hardhat 2 is reaching end of life and is being replaced by Hardhat 3**]
+Hardhat 3 is stable and production ready, and teams are already migrating.
+Hardhat 2 will be upgraded to support the Glamsterdam hardfork and will continue
+to receive bug fixes and security fixes until its **end of life** — the earlier
+of the **Hegota mainnet activation** or the **1<sup>st</sup> of July 2027**.
+After that, there will be no further Hardhat 2 releases.
+
+**Plan your migration to Hardhat 3 now**.
+:::
+
+Hardhat 3 is stable and production ready: Solidity tests as first-class,
+multi-chain support, a performant Rust-powered runtime via EDR. To support the
+changing Node.js ecosystem, Hardhat 3 and its plugin system have been redesigned
+to be ESM native.
+
+Hardhat will always put stability first, which is why Hardhat 3 has spent the
+last 9 months in beta: stabilizing the API, closing bugs and removing migration
+friction for our Hardhat 2 users. Teams across the ecosystem are already moving
+over, see our
+[migration guide](https://hardhat.org/docs/migrate-from-hardhat2) to join
+them (or our
+[Foundry migration guide](https://hardhat.org/docs/migrate-from-foundry)
+for projects coming across).
+
+## Hardhat 2 end of life
+
+We are introducing an **end of life** policy for Hardhat 2, as the Node.js
+ecosystem moves beyond the CommonJS module system it uses.
+
+Hardhat 2 will be upgraded to support the **Glamsterdam** hardfork and will
+continue to receive bug fixes and security fixes until it reaches end of life.
+It will **not** be upgraded to the **Hegota** hardfork or any of its EIPs.
+
+Hardhat 2 will reach **end of life** on whichever date comes first between:
+
+- the activation of **the Hegota hardfork** on Ethereum mainnet
+- the **1<sup>st</sup> of July 2027**, if Hegota is delayed
+
+After that date, no further releases should be expected, including for security
+fixes. If you haven't started yet, now is the time to plan your move to
+Hardhat 3. The
+[Hardhat 2 migration guide](https://hardhat.org/docs/migrate-from-hardhat2)
+walks you through the upgrade in just a few easy steps, and we are rolling out
+an agent skill soon which can migrate most of your repository automatically.

--- a/src/content/hardhat-runner/docs/reference/hardhat-2-end-of-life.md
+++ b/src/content/hardhat-runner/docs/reference/hardhat-2-end-of-life.md
@@ -2,7 +2,7 @@
 Hardhat 3 is stable and production ready, and teams are already migrating.
 Hardhat 2 will be upgraded to support the Glamsterdam hardfork and will continue
 to receive bug fixes and security fixes until its **end of life** — the earlier
-of the **Hegota mainnet activation** or the **1<sup>st</sup> of July 2027**.
+of the **Hegota mainnet activation** or the **1<sup>st</sup> of June 2027**.
 After that, there will be no further Hardhat 2 releases.
 
 **Plan your migration to Hardhat 3 now**.

--- a/src/content/hardhat-runner/docs/reference/hardhat-2-end-of-life.md
+++ b/src/content/hardhat-runner/docs/reference/hardhat-2-end-of-life.md
@@ -34,7 +34,7 @@ It will **not** be upgraded to the **Hegota** hardfork or any of its EIPs.
 Hardhat 2 will reach **end of life** on whichever date comes first between:
 
 - the activation of **the Hegota hardfork** on Ethereum mainnet
-- the **1<sup>st</sup> of July 2027**, if Hegota is delayed
+- the **1<sup>st</sup> of June 2027**, if Hegota is delayed
 
 After that date, no further releases should be expected, including for security
 fixes. If you haven't started yet, now is the time to plan your move to

--- a/src/model/plugins.tsx
+++ b/src/model/plugins.tsx
@@ -99,32 +99,91 @@ export const sortPluginsByDownloads = (downloadsD: {
   }
 };
 
-const getLastMonthDownloads = async (npmPackage: string): Promise<number> => {
-  const res = await request(
-    `https://api.npmjs.org/downloads/point/last-month/${npmPackage}`,
-    {
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+// How many download lookups to run at once, and how many times to retry a
+// single lookup before giving up.
+const DOWNLOADS_CONCURRENCY = 8;
+const DOWNLOADS_MAX_ATTEMPTS = 4;
+
+// Splits an array into chunks of at most `size` items.
+const chunk = <T,>(items: T[], size: number): T[][] => {
+  const result: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    result.push(items.slice(i, i + size));
+  }
+  return result;
+};
+
+// Fetches the last month's download count for an npm package. Returns 0 on any
+// failure (404, rate-limit, non-JSON body, network error) so a flaky
+// api.npmjs.org response can never break the build. api.npmjs.org sits behind
+// Cloudflare, which rate-limits bursts with a non-JSON "error code: 1015" body;
+// we retry those with a backoff before falling back to 0. Implemented
+// recursively so a single lookup never loops with `await`.
+const getLastMonthDownloads = async (
+  npmPackage: string,
+  attempt = 1
+): Promise<number> => {
+  const url = `https://api.npmjs.org/downloads/point/last-month/${npmPackage}`;
+  const canRetry = attempt < DOWNLOADS_MAX_ATTEMPTS;
+  const retry = async () => {
+    await sleep(attempt * 1000);
+    return getLastMonthDownloads(npmPackage, attempt + 1);
+  };
+
+  try {
+    const res = await request(url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",
       },
+    });
+
+    if (res.statusCode === 404) {
+      await res.body.dump();
+      return 0;
     }
-  );
 
-  if (res.statusCode === 404) {
-    return 0;
+    // Rate-limited or transient server error: back off and retry.
+    if (res.statusCode === 429 || res.statusCode >= 500) {
+      await res.body.dump();
+      return canRetry ? await retry() : 0;
+    }
+
+    if (res.statusCode !== 200) {
+      await res.body.dump();
+      return 0;
+    }
+
+    const json = (await res.body.json()) as { downloads: number };
+    return json.downloads;
+  } catch {
+    // Network error or a non-JSON body (e.g. a Cloudflare rate-limit page).
+    return canRetry ? await retry() : 0;
   }
-
-  const json = (await res.body.json()) as { downloads: number };
-
-  return json.downloads;
 };
 
 export const generatePluginsDownloads = async (pluginsD: typeof plugins) => {
-  const downloads: Array<{ [plugin: string]: number }> = await Promise.all(
-    pluginsD.communityPlugins.map(async (p: any) => ({
-      [p.name]: await getLastMonthDownloads(p.npmPackage ?? p.name),
-    }))
+  // Process in small batches instead of firing every request at once, to avoid
+  // being rate-limited by api.npmjs.org when there are many plugins.
+  const batches = chunk(pluginsD.communityPlugins, DOWNLOADS_CONCURRENCY);
+
+  const downloads = await batches.reduce(
+    async (accPromise: Promise<Array<{ [plugin: string]: number }>>, batch) => {
+      const acc = await accPromise;
+      const batchDownloads = await Promise.all(
+        batch.map(async (p: any) => ({
+          [p.name]: await getLastMonthDownloads(p.npmPackage ?? p.name),
+        }))
+      );
+      return acc.concat(batchDownloads);
+    },
+    Promise.resolve([])
   );
 
   downloads.sort((p1, p2) => Object.values(p2)[0] - Object.values(p1)[0]);


### PR DESCRIPTION
Add the Hardhat 2 end of life policy to the Hardhat 3 website.

Add tips at the top of the intro and getting started guides pointing at Hardhat 3.

## Previews

- End of life policy https://hardhat-website-git-v2-end-of-life-nomic-foundation.vercel.app/hardhat-runner/docs/reference/hardhat-2-end-of-life
- documentation - https://hardhat-website-git-v2-end-of-life-nomic-foundation.vercel.app/docs
- overview/getting started - https://hardhat-website-git-v2-end-of-life-nomic-foundation.vercel.app/hardhat-runner/docs/getting-started#overview

## Build system fixes

The Hardhat 2 website has not been released recently, I needed to make several changes to get it to working:

* add a retry to the npm lookup
