### PR TITLE
docs: clarify that solidity --snapshot-check is read-only

### DIFF
--- a/src/content/docs/docs/guides/testing/gas-snapshots.mdx
+++ b/src/content/docs/docs/guides/testing/gas-snapshots.mdx
@@ -50,11 +50,11 @@ Function gas snapshots: 1 changed
 To update snapshots, run your tests with --snapshot
 ```
 
-The check only fails when existing values change. Adding or removing test functions or cheatcode snapshot calls won't cause a failure.
+The check only fails when existing values change, or when no snapshots exist yet and there's nothing to compare against. Adding or removing test functions or cheatcode snapshot calls won't cause a failure.
 
 :::note
 
-`--snapshot-check` only reads your snapshot files. It never creates, updates, or deletes them. Use `--snapshot` to update the baseline. If no snapshots exist yet, it reports that there's nothing to compare against and suggests running `--snapshot`.
+`--snapshot-check` only reads your snapshot files. It never creates, updates, or deletes them. Use `--snapshot` to update your snapshots.
 
 :::
 

--- a/src/content/docs/docs/guides/testing/gas-snapshots.mdx
+++ b/src/content/docs/docs/guides/testing/gas-snapshots.mdx
@@ -52,6 +52,12 @@ To update snapshots, run your tests with --snapshot
 
 The check only fails when existing values change. Adding or removing test functions or cheatcode snapshot calls won't cause a failure.
 
+:::note
+
+`--snapshot-check` only reads your snapshot files; it never creates, updates, or deletes them. Use `--snapshot` to update the baseline. If no snapshots exist yet, it reports that there's nothing to compare against and suggests running `--snapshot`.
+
+:::
+
 ## Function gas snapshots
 
 The `.gas-snapshot` file records the gas used by each test function. Each line contains the contract name, function name, and gas details:

--- a/src/content/docs/docs/guides/testing/gas-snapshots.mdx
+++ b/src/content/docs/docs/guides/testing/gas-snapshots.mdx
@@ -54,7 +54,7 @@ The check only fails when existing values change. Adding or removing test functi
 
 :::note
 
-`--snapshot-check` only reads your snapshot files; it never creates, updates, or deletes them. Use `--snapshot` to update the baseline. If no snapshots exist yet, it reports that there's nothing to compare against and suggests running `--snapshot`.
+`--snapshot-check` only reads your snapshot files. It never creates, updates, or deletes them. Use `--snapshot` to update the baseline. If no snapshots exist yet, it reports that there's nothing to compare against and suggests running `--snapshot`.
 
 :::
 


### PR DESCRIPTION
Adds a note to the gas snapshots guide explaining that `hardhat test solidity --snapshot-check` only reads the snapshot files and never modifies them.

Related to: https://github.com/NomicFoundation/hardhat/pull/8391.