### PR TITLE
docs: remove Base Mainnet support claims from OP Stack docs

### DIFF
--- a/src/content/docs/docs/reference/edr-simulated-networks.mdx
+++ b/src/content/docs/docs/reference/edr-simulated-networks.mdx
@@ -35,7 +35,7 @@ export default defineConfig({
     },
     hardhatOptimism: {
       type: "edr-simulated",
-      chainType: "op", // OP Stack chains, like OP Mainnet, Base, or their testnets
+      chainType: "op", // OP Stack chains, like OP Mainnet or its testnets
     },
     other: {
       type: "edr-simulated",

--- a/src/content/docs/docs/reference/op-stack-support.mdx
+++ b/src/content/docs/docs/reference/op-stack-support.mdx
@@ -48,6 +48,7 @@ export default defineConfig({
 ```
 
 To fork a different OP Stack chain, like Ink, change the `chainId` and the RPC URL:
+
 ```ts del={2-3} ins={4-5}
       chainType: "op",
       chainId: 10,

--- a/src/content/docs/docs/reference/op-stack-support.mdx
+++ b/src/content/docs/docs/reference/op-stack-support.mdx
@@ -47,6 +47,15 @@ export default defineConfig({
 });
 ```
 
+To fork a different OP Stack chain, like Ink, change the `chainId` and the RPC URL:
+```ts del={2-3} ins={4-5}
+      chainType: "op",
+      chainId: 10,
+      forking: { url: configVariable("OP_MAINNET_RPC_URL") },
+      chainId: 57073,
+      forking: { url: configVariable("INK_MAINNET_RPC_URL") },
+```
+
 ### Base fee accuracy on local chains
 
 Since the Holocene hardfork, OP Stack chains define their EIP-1559 base fee parameters dynamically, and these are expressed as block-number activations. On forked chains this works as expected, since they start at the forked block number. On local (non-forked) chains, the genesis block starts at block `0`, so some of these activations may not take effect as expected.

--- a/src/content/docs/docs/reference/op-stack-support.mdx
+++ b/src/content/docs/docs/reference/op-stack-support.mdx
@@ -19,11 +19,11 @@ Here's what changes compared to the `l1` Chain Type:
 
 ## Supported chains
 
-Hardhat includes built-in chain-specific parameters for many OP Stack chains, including OP Mainnet, Base, and their testnets. These parameters are sourced from the [Optimism Superchain Registry](https://github.com/ethereum-optimism/superchain-registry) and include chain IDs, hardfork activation block numbers, and EIP-1559 base fee configuration.
+Hardhat includes built-in chain-specific parameters for many OP Stack chains, including OP Mainnet and its testnets. These parameters are sourced from the [Optimism Superchain Registry](https://github.com/ethereum-optimism/superchain-registry) and include chain IDs, hardfork activation block numbers, and EIP-1559 base fee configuration.
 
 When you configure a network with `chainType: "op"` and the right `chainId`, the correct parameters are applied automatically.
 
-OP Mainnet and Base are actively maintained, while other chains have default parameters that may not be fully up-to-date.
+OP Mainnet is actively maintained, while other chains have default parameters that may not be fully up-to-date.
 
 Here's an example of forking OP Mainnet:
 
@@ -47,18 +47,8 @@ export default defineConfig({
 });
 ```
 
-To fork Base instead, just change the `chainId` and RPC URL:
-
-```ts del={2-3} ins={4-5}
-      chainType: "op",
-      chainId: 10,
-      forking: { url: configVariable("OP_MAINNET_RPC_URL") },
-      chainId: 8453,
-      forking: { url: configVariable("BASE_MAINNET_RPC_URL") },
-```
-
 ### Base fee accuracy on local chains
 
 Since the Holocene hardfork, OP Stack chains define their EIP-1559 base fee parameters dynamically, and these are expressed as block-number activations. On forked chains this works as expected, since they start at the forked block number. On local (non-forked) chains, the genesis block starts at block `0`, so some of these activations may not take effect as expected.
 
-{/* NOTE: If Hardhat exposes EDR's `baseFeeConfig` option in the future, update the paragraph above to mention that users can override base fee parameters manually. */}
+{/_ NOTE: If Hardhat exposes EDR's `baseFeeConfig` option in the future, update the paragraph above to mention that users can override base fee parameters manually. _/}


### PR DESCRIPTION
Our OP Stack support is built around standard OP Stack execution semantics.

With the [Azul hardfork](https://docs.base.org/base-chain/specs/upgrades/azul/overview), Base has diverged from the standard OP Stack specification, so we can no longer guarantee that Hardhat's `op` chain type accurately simulates Base. 

To avoid implying support we don't actually provide, we're removing Base-specific claims from the docs.
 
OP Mainnet and other standard-conforming chains are unaffected.
