### PR TITLE
docs: add migration guides

### DIFF
--- a/src/content/docs/docs/migrate-from-foundry/guides/migration-skill.mdx
+++ b/src/content/docs/docs/migrate-from-foundry/guides/migration-skill.mdx
@@ -1,0 +1,52 @@
+---
+title: Migrate with an AI agent
+description: How to install and run the Foundry to Hardhat migration skill
+sidebar:
+  label: Migrate with an AI agent
+  order: 99
+---
+
+import RunRemote from "@hh/RunRemote.astro";
+
+If you use an AI coding agent, our Foundry to Hardhat migration skill allows it to perform a structured migration of your project.
+
+## Install the skill
+
+Install the skill in your project:
+
+<RunRemote command="skills add nomicfoundation/hardhat-skills --skill migrate-foundry-to-hardhat" />
+
+This launches an interactive CLI that will walk you through installing the migration skill for your agent. For instance, you can choose to install into your current project (rather than globally) and specifically for Claude, which writes the skill files into `.claude/skills/` at the repository root.
+
+## Run the migration
+
+Open your project in your coding agent and ask it to migrate from Foundry to Hardhat 3, for example:
+
+> Migrate this project from Foundry to Hardhat 3 using the Hardhat migration skill.
+
+For Claude you can invoke the migration as a command with:
+
+```
+/migrate-foundry-to-hardhat
+```
+
+The agent will use the skill to start a campaign to migrate the repo to Hardhat 3. The agent will migrate the project by systematically working through the following steps in order:
+
+1. **Analyze** the Foundry project including `foundry.toml`, remappings, submodules, inline config, and scripts.
+2. **Add Hardhat** to the project with the detected package manager.
+3. **Create `hardhat.config.ts`**, mapping every `foundry.toml` section across.
+4. **Handle absolute imports** and remapping differences.
+5. **Compile** the contracts.
+6. **Run Solidity tests** and get them passing.
+7. **Migration report** covering migration gaps and a Foundry cleanup checklist.
+
+## Review the result
+
+The skill automates the migration, but you should still review the changes and verify your core development workflows are correct, for example:
+
+```sh
+npx hardhat build
+npx hardhat test
+```
+
+Further manual migration may be necessary for additional workflows e.g. CI, deployment, specialist scripts etc.

--- a/src/content/docs/docs/migrate-from-foundry/index.mdx
+++ b/src/content/docs/docs/migrate-from-foundry/index.mdx
@@ -12,10 +12,7 @@ import Run from "@hh/Run.astro";
 import RunRemote from "@hh/RunRemote.astro";
 
 :::tip
-If you use an AI coding agent, you can install our Foundry to Hardhat migration skill to have it aid your migration:
-
-<RunRemote command="skills add nomicfoundation/hardhat-skills --skill migrate-foundry-to-hardhat" />
-
+If you use an AI coding agent, you can leverage our _Foundry to Hardhat migration skill_ to have it run your migration. See [Migrate with an AI agent](/docs/migrate-from-foundry/guides/migration-skill) for details.
 :::
 
 Hardhat 3 is a full replacement for Foundry: it runs Solidity tests, understands `remappings.txt`, and can build contracts laid out the way Foundry expects.

--- a/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/guides/migrate-to-esm.mdx
@@ -3,6 +3,7 @@ title: Migrate your project to ESM
 description: How to convert a Hardhat project from CommonJS to ES modules
 sidebar:
   label: Migrate to ESM
+  order: 1
 ---
 
 import { TabItem, Tabs } from "@astrojs/starlight/components";

--- a/src/content/docs/docs/migrate-from-hardhat2/guides/migration-skill.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/guides/migration-skill.mdx
@@ -1,0 +1,51 @@
+---
+title: Migrate with an AI agent
+description: How to install and run the Hardhat 2 to Hardhat 3 migration skill
+sidebar:
+  label: Migrate with an AI agent
+  order: 99
+---
+
+import RunRemote from "@hh/RunRemote.astro";
+
+If you use an AI coding agent, our Hardhat 2 to Hardhat 3 migration skill allows it to perform a structured migration of your project.
+
+## Install the skill
+
+Install the skill in your project:
+
+<RunRemote command="skills add nomicfoundation/hardhat-skills --skill migrate-hardhat2-to-hardhat3" />
+
+This launches an interactive CLI that will walk you through installing the migration skill for your agent. For instance, you can choose to install into your current project (rather than globally) and specifically for Claude, which writes the skill files into `.claude/skills/` at the repository root.
+
+## Run the migration
+
+Open your project in your coding agent and ask it to migrate to Hardhat 3, for example:
+
+> Migrate this project from Hardhat 2 to Hardhat 3 using the Hardhat migration skill.
+
+For Claude you can invoke the migration as a command with:
+
+```
+/migrate-hardhat2-to-hardhat3
+```
+
+The agent will use the skill to start a campaign to migrate the repo to Hardhat 3. The migration will proceed step by step, pausing for review after each:
+
+1. **Project setup** — `tsconfig.json` for ESM and the `package.json` Hardhat 2 to Hardhat 3 dependency swap.
+2. **Config** — rewrite `hardhat.config.ts` to the declarative `defineConfig` (plugins, networks, tasks, solidity, verify etc).
+3. **Solidity tests** — migrate `.t.sol` files to Hardhat 3 conventions.
+4. **Source files** — convert `.ts`/`.js` sources CJS to ESM and update Hardhat 2 APIs to Hardhat 3 (plus TypeChain import fixes).
+5. **Test fix-up** — get the TypeScript test suite passing under Hardhat 3.
+6. **Script validation** — run and fix the `package.json` scripts you select.
+
+## Review the result
+
+The skill automates the migration, but you should still review the changes and verify your core development workflows are correct, for example:
+
+```sh
+npx hardhat build
+npx hardhat test
+```
+
+Further manual migration may be necessary for additional workflows e.g. CI, deployment, specialist scripts etc.

--- a/src/content/docs/docs/migrate-from-hardhat2/guides/mocha-tests.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/guides/mocha-tests.mdx
@@ -3,6 +3,7 @@ title: Migrate Mocha tests from Hardhat 2
 description: How to migrate Mocha tests from Hardhat 2 to Hardhat 3
 sidebar:
   label: Migrate Mocha tests
+  order: 2
 ---
 
 This guide walks you through the changes needed to migrate your Mocha tests from Hardhat 2 to Hardhat 3.

--- a/src/content/docs/docs/migrate-from-hardhat2/index.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/index.mdx
@@ -10,10 +10,7 @@ import Run from "@hh/Run.astro";
 import RunRemote from "@hh/RunRemote.astro";
 
 :::tip
-If you use an AI coding agent, you can install our Hardhat 2 to Hardhat 3 migration skill to have it aid your migration:
-
-<RunRemote command="skills add nomicfoundation/hardhat-skills --skill migrate-hardhat2-to-hardhat3" />
-
+If you use an AI coding agent, you can leverage our _Hardhat 2 to Hardhat 3 migration skill_ to have it run your migration. See [Migrate with an AI agent](/docs/migrate-from-hardhat2/guides/migration-skill) for details.
 :::
 
 Hardhat 3 is a complete rewrite of Hardhat 2. While many features are familiar, several fundamental changes mean the new version isn't directly compatible with Hardhat 2 projects:

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -202,6 +202,12 @@ export const sidebarTopics: StarlightSidebarTopicsUserConfig = [
       {
         slug: "docs/migrate-from-foundry",
       },
+      {
+        label: "Guides",
+        autogenerate: {
+          directory: "/docs/migrate-from-foundry/guides",
+        },
+      },
     ],
   },
   {


### PR DESCRIPTION
Add separate mini-guides to using the Migration skills.