### PR TITLE
docs: add EIP-7778 and EIP-7928 to amsterdam page

### DIFF
--- a/src/content/docs/docs/reference/amsterdam-support.mdx
+++ b/src/content/docs/docs/reference/amsterdam-support.mdx
@@ -24,6 +24,8 @@ We are implementing Amsterdam's EIPs incrementally, and will add more as the har
 The following Amsterdam EIPs are currently supported:
 
 - [EIP-7708: ETH transfers emit logs](#eip-7708-eth-transfers-emit-logs)
+- [EIP-7778: block gas accounting excludes refunds](#eip-7778-block-gas-accounting-excludes-refunds)
+- [EIP-7928: block-level access list hash](#eip-7928-block-level-access-list-hash)
 
 ## Enabling Amsterdam
 
@@ -128,3 +130,15 @@ for (const log of transferLogs) {
 Running it prints a log emitted by the system address, with the `from` and `to` addresses derived from its topics and the transferred amount from its data:
 
 <Run command="hardhat run scripts/transfer-logs.ts" />
+
+## EIP-7778: block gas accounting excludes refunds
+
+Under [EIP-7778](https://eips.ethereum.org/EIPS/eip-7778), gas refunds no longer reduce the gas counted towards the block gas limit. From Amsterdam onwards, a block's `gasUsed` reflects the gross gas spent by its transactions, without subtracting refunds. This only affects block-level accounting; per-transaction costs are unchanged.
+
+In practice, this may affect test suites that assert on a block's `gasUsed`, which can now be higher than on earlier hardforks if there are transactions that trigger refunds.
+
+## EIP-7928: block-level access list hash
+
+[EIP-7928](https://eips.ethereum.org/EIPS/eip-7928) introduces block-level access lists, which record every account and storage slot accessed while executing a block. Amsterdam blocks carry a new `blockAccessListHash` header field: the `keccak256` hash of the RLP-encoded block-level access list.
+
+Hardhat's simulated network populates this field so that it is present on Amsterdam blocks, but its value is a placeholder and does not match the value a real network would produce. Don't assert on specific `blockAccessListHash` values.


### PR DESCRIPTION
Add entries for the two new EIPs implemented as part of EDR 0.14.2.

## Preview

https://hardhat-website-git-add-to-amsterdam-su-f44fdc-nomic-foundation.vercel.app/docs/reference/amsterdam-support#supported-features