### PR TITLE
docs: align Node.js minimum version to v22.13.0

### DIFF
--- a/src/content/docs/docs/migrate-from-hardhat2/index.mdx
+++ b/src/content/docs/docs/migrate-from-hardhat2/index.mdx
@@ -28,7 +28,7 @@ Before making any changes, prepare your project so that installing and running H
 
 1.  **Check node.js version**
 
-    Make sure you are using Node.js v22.10.0 or later:
+    Make sure you are using Node.js v22.13.0 or later:
 
     ```sh
     node --version

--- a/src/content/docs/ignition/docs/getting-started.mdx
+++ b/src/content/docs/ignition/docs/getting-started.mdx
@@ -33,7 +33,7 @@ If you don't have a Hardhat project yet, or if you want to create a new one to t
 To install Hardhat Ignition in an existing Hardhat project, you will need:
 
 - Hardhat version 3.0.0 or higher
-- [Node.js](https://nodejs.org/) version 22.10.0 or higher
+- [Node.js](https://nodejs.org/) version 22.13.0 or higher
 - A package manager like [npm](https://www.npmjs.com/), [pnpm](https://pnpm.io/), or [yarn](https://yarnpkg.com/)
 
 You can also follow [Hardhat's Quick Start guide](/docs/getting-started) to create a new project from scratch to follow this guide.


### PR DESCRIPTION
## Summary
- Update remaining docs that still said Node.js **v22.10.0** to **v22.13.0**, matching Hardhat 3’s CLI check (`MIN_SUPPORTED_NODE_VERSION = [22, 13, 0]`)
- Pages: Hardhat 2 migration guide + Ignition getting started
- `getting-started.mdx` / Foundry migration / tutorial / nodejs-support already correctly say 22.13.0

Related: NomicFoundation/hardhat#8293 (complements the stale/conflicting website PR #262 which only touched getting-started)

## Test plan
- [x] Grep confirms no remaining `22.10.0` in `src/**/*.mdx`
- [ ] Docs preview / CI green