### PR TITLE
docs: add EIP-7843 to amsterdam support

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -81,3 +81,4 @@ resumability
 uninstrumented
 Glamsterdam
 Hegota
+slotnum

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@astrojs/vercel": "^8.2.8",
     "@expressive-code/plugin-collapsible-sections": "^0.41.3",
     "@expressive-code/plugin-line-numbers": "^0.41.3",
-    "@nomicfoundation/hardhat-errors": "^3.0.16",
+    "@nomicfoundation/hardhat-errors": "^3.0.17",
     "@types/tar-stream": "^3.1.4",
     "astro": "^5.6.1",
     "cspell": "^9.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^0.41.3
         version: 0.41.3
       '@nomicfoundation/hardhat-errors':
-        specifier: ^3.0.16
-        version: 3.0.16
+        specifier: ^3.0.17
+        version: 3.0.17
       '@types/tar-stream':
         specifier: ^3.1.4
         version: 3.1.4
@@ -767,11 +767,11 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/hardhat-errors@3.0.16':
-    resolution: {integrity: sha512-z3hxWX2vG0C0JBojKHcUjArOXftHQZ2cPnHOSReILq6/UZXuzm9WIEBDPbotH2tgjRDKBlh0+XOpJZjFhEODIw==}
+  '@nomicfoundation/hardhat-errors@3.0.17':
+    resolution: {integrity: sha512-x8/Bv7Mn0a90ZRX4ZfWuq8uGuqF10LzLMXD1LD0kEIRBwSvr71fcxYyONcuf+MzznbrJ+WBTNz3ov9Rd++8DfQ==}
 
-  '@nomicfoundation/hardhat-utils@4.1.4':
-    resolution: {integrity: sha512-DEAu/uIBTNkPedfTnokh6tKum/Kxr5xMlh8ZovBGqlKA8AlxP26J0PBjK73fmeUQ0sh432suWksSr5CtHVG04A==}
+  '@nomicfoundation/hardhat-utils@4.1.6':
+    resolution: {integrity: sha512-j3LUq/4puVWUaS5BsbehR90LiGZaABYAWHSA4nGfRUxfBUjay82AwSSzaGKfDQYaRkdKoP9ZXeMDTEIFJGI24Q==}
 
   '@nomicfoundation/slang@1.2.0':
     resolution: {integrity: sha512-+04Z1RHbbz0ldDbHKQFOzveCdI9Rd3TZZu7fno5hHy3OsqTo9UK5Jgqo68wMvRovCO99POv6oCEyO7+urGeN8Q==}
@@ -3779,11 +3779,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nomicfoundation/hardhat-errors@3.0.16':
+  '@nomicfoundation/hardhat-errors@3.0.17':
     dependencies:
-      '@nomicfoundation/hardhat-utils': 4.1.4
+      '@nomicfoundation/hardhat-utils': 4.1.6
 
-  '@nomicfoundation/hardhat-utils@4.1.4':
+  '@nomicfoundation/hardhat-utils@4.1.6':
     dependencies:
       '@streamparser/json-node': 0.0.22
       env-paths: 2.2.1

--- a/src/content/docs/docs/reference/amsterdam-support.mdx
+++ b/src/content/docs/docs/reference/amsterdam-support.mdx
@@ -25,6 +25,7 @@ The following Amsterdam EIPs are currently supported:
 
 - [EIP-7708: ETH transfers emit logs](#eip-7708-eth-transfers-emit-logs)
 - [EIP-7778: Block Gas Accounting without Refunds](#eip-7778-block-gas-accounting-without-refunds)
+- [EIP-7843: SLOTNUM opcode](#eip-7843-slotnum-opcode)
 - [EIP-7928: Block-Level Access Lists](#eip-7928-block-level-access-lists)
 
 ## Enabling Amsterdam
@@ -136,6 +137,40 @@ Running it prints a log emitted by the system address, with the `from` and `to` 
 Under [EIP-7778](https://eips.ethereum.org/EIPS/eip-7778), gas refunds no longer reduce the gas counted towards the block gas limit. From Amsterdam onwards, a block's `gasUsed` reflects the gross gas spent by its transactions, without subtracting refunds. This only affects block-level accounting; per-transaction costs are unchanged.
 
 In practice, this may affect test suites that assert on a block's `gasUsed`, which can now be higher than on earlier hardforks if there are transactions that trigger refunds.
+
+## EIP-7843: SLOTNUM opcode
+
+[EIP-7843](https://eips.ethereum.org/EIPS/eip-7843) exposes the consensus-layer slot number to the execution layer, so contracts can read it without hardcoding slot-length calculations or checking it against a beacon root. Amsterdam blocks carry a new `slotNumber` header field, and the new `SLOTNUM` (`0x4b`) opcode returns the executing block's slot number. In practice, most test suites won't need the slot number.
+
+Hardhat's simulated network has no consensus layer, so it simulates the slot number. On a new chain it starts at 0, and it increments by one for every mined block, including the blocks that `hardhat_mine` fast-forwards through. When you fork, the forked block keeps its original slot number, and blocks mined on top of it continue from there.
+
+The simulated value is deterministic, but it doesn't advance the way a real network's does. On Ethereum, slots advance at a fixed interval regardless of whether a validator proposes a block. Because some slots are empty, consecutive blocks often have non-consecutive slot numbers. Don't rely on one slot per block outside of a simulated network.
+
+`slotNumber` isn't part of the standard block response. To read it, send a raw JSON-RPC request:
+
+```ts
+// scripts/slot-number.ts
+import { network } from "hardhat";
+
+const { provider } = await network.create({ network: "edrAmsterdam" });
+
+for (let i = 0; i < 3; i++) {
+  await provider.request({ method: "hardhat_mine", params: [] });
+
+  const block = (await provider.request({
+    method: "eth_getBlockByNumber",
+    params: ["latest", false],
+  })) as { number: string; slotNumber: string };
+
+  console.log(
+    `block ${BigInt(block.number)} has slot number ${BigInt(block.slotNumber)}`,
+  );
+}
+```
+
+Running it prints the slot number of each newly mined block:
+
+<Run command="hardhat run scripts/slot-number.ts" />
 
 ## EIP-7928: Block-Level Access Lists
 


### PR DESCRIPTION
Add a section to the Amsterdam support page explaining `EIP-7843: SLOTNUM opcode`.

## Preview

https://hardhat-website-git-add-eip-7843-to-ams-33161e-nomic-foundation.vercel.app/docs/reference/amsterdam-support#eip-7843-slotnum-opcode